### PR TITLE
feat: FortuneResultのdecodeを明示的に定義

### DIFF
--- a/YumemiPrefectureFortune/Model/DTOs.swift
+++ b/YumemiPrefectureFortune/Model/DTOs.swift
@@ -19,4 +19,13 @@ struct FortuneRequestDTO: Encodable {
 
 struct FortuneResult: Decodable {
     let prefecture: Prefecture
+    
+    init(prefecture: Prefecture) {
+        self.prefecture = prefecture
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.prefecture = try container.decode(Prefecture.self)
+    }
 }


### PR DESCRIPTION
decoderからの初期化を明示的に定義しprefecture {} と囲まれるのを削除
## 変更前のデコード可能なJSON
{
  "prefecture": {
    "name": "富山県",
    "brief": "富山県（とやまけん）は、日本の中部地方に位置する県。県庁所在地は富山市。\n中部地方の日本海側、新潟県を含めた場合の北陸地方のほぼ中央にある。\n※出典: フリー百科事典『ウィキペディア（Wikipedia）』",
    "capital": "富山市",
    "citizen_day": {
      "month": 5,
      "day": 9
  },
  "has_coast_line": true,
  "logo_url": "https://japan-map.com/wp-content/uploads/toyama.png"
  }
}
## 変更後のデコード可能なJSON
{
  "name": "富山県",
  "brief": "富山県（とやまけん）は、日本の中部地方に位置する県。県庁所在地は富山市。\n中部地方の日本海側、新潟県を含めた場合の北陸地方のほぼ中央にある。\n※出典: フリー百科事典『ウィキペディア（Wikipedia）』",
  "capital": "富山市",
  "citizen_day": {
    "month": 5,
    "day": 9
  },
  "has_coast_line": true,
  "logo_url": "https://japan-map.com/wp-content/uploads/toyama.png"
}