### PR TITLE
  feat: 占いAPIの通信機能と単体テストを実装

### DIFF
--- a/YumemiPrefectureFortune/Services/FortuneAPIService.swift
+++ b/YumemiPrefectureFortune/Services/FortuneAPIService.swift
@@ -22,6 +22,45 @@ protocol FortuneAPIServiceProtocol {
  /// 占いAPIとの通信を実際に担当するクラス
 final class FortuneAPIService: FortuneAPIServiceProtocol {
     
+    private let session: URLSession
+
+    // テスト時に外部からURLSessionを注入できるようにする
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+    
     func fetchFortune(from requestDTO: FortuneRequestDTO) async throws -> FortuneResult {
+        guard let url = URL(string: "https://yumemi-inc.github.io/ios-junior-engineer-codecheck-backend/my_fortune") else {
+            throw APIError.invalidURL
+        }
+        
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue("v1", forHTTPHeaderField: "API-Version")
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        urlRequest.httpBody = try encoder.encode(requestDTO)
+        
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await self.session.data(for: urlRequest)
+        } catch {
+            throw APIError.networkError(error)
+        }
+        
+        guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw APIError.badStatusCode(statusCode)
+        }
+        
+        do {
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            return try decoder.decode(FortuneResult.self, from: data)
+        } catch {
+            throw APIError.decodingError(error)
+        }
     }
 }

--- a/YumemiPrefectureFortune/Services/FortuneAPIService.swift
+++ b/YumemiPrefectureFortune/Services/FortuneAPIService.swift
@@ -8,3 +8,20 @@ enum APIError: Error {
     case badStatusCode(Int)
     case decodingError(Error)
 }
+
+// MARK: - Service Protocol
+
+/// 占いAPIサービスクラスが準拠するプロトコル
+/// これを定義することで、テスト時にモックを注入しやすくなる
+protocol FortuneAPIServiceProtocol {
+    func fetchFortune(from requestDTO: FortuneRequestDTO) async throws -> FortuneResult
+}
+
+ // MARK: - Service Implementation
+
+ /// 占いAPIとの通信を実際に担当するクラス
+final class FortuneAPIService: FortuneAPIServiceProtocol {
+    
+    func fetchFortune(from requestDTO: FortuneRequestDTO) async throws -> FortuneResult {
+    }
+}

--- a/YumemiPrefectureFortune/Services/FortuneAPIService.swift
+++ b/YumemiPrefectureFortune/Services/FortuneAPIService.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+// MARK: - API Error
+
+enum APIError: Error {
+    case invalidURL
+    case networkError(Error)
+    case badStatusCode(Int)
+    case decodingError(Error)
+}

--- a/YumemiPrefectureFortuneTests/FortuneAPIServiceTests.swift
+++ b/YumemiPrefectureFortuneTests/FortuneAPIServiceTests.swift
@@ -1,0 +1,153 @@
+import Testing
+import Foundation
+import XCTest // For XCTFail
+@testable import YumemiPrefectureFortune
+
+final class FortuneAPIServiceTests {
+
+    var apiService: FortuneAPIService!
+    var session: URLSession!
+
+    // MARK: - Helper
+    
+    let testBundle: Bundle = {
+        guard let bundle = Bundle(identifier: "com.TEIKOTA.YumemiPrefectureFortuneTests") else {
+            fatalError("テストバンドルが見つからない")
+        }
+        return bundle
+    }()
+
+    /// テストバンドルからJSONファイルを読み込むためのヘルパーメソッド
+    private func data(forResource name: String) throws -> Data {
+        let url = try #require(testBundle.url(forResource: name, withExtension: "json"))
+        return try Data(contentsOf: url)
+    }
+
+    // MARK: - Setup with MockURLProtocol
+
+    func setup(withResponseData data: Data? = nil, statusCode: Int = 200, error: Error? = nil) {
+        MockURLProtocol.requestHandler = { request in
+            if let error = error {
+                throw error
+            }
+            let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+            return (response, data)
+        }
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        session = URLSession(configuration: config)
+        apiService = FortuneAPIService(session: session)
+    }
+
+    // MARK: - Tests
+
+    @Test("正常系: FortuneAPIServiceが成功レスポンスを返す")
+    func testFetchFortuneSuccess() async throws {
+        let responseData = try data(forResource: "responseExample")
+        setup(withResponseData: responseData)
+
+        let requestDTO = FortuneRequestDTO(
+            name: "ゆめみん",
+            birthday: YMD(year: 2000, month: 1, day: 27),
+            bloodType: "ab",
+            today: YMD(year: 2000, month: 1, day: 27)
+        )
+
+        let result = try await apiService.fetchFortune(from: requestDTO)
+        #expect(result.prefecture.name == "富山県")
+        #expect(result.prefecture.capital == "富山市")
+    }
+
+    @Test("異常系: ネットワークエラーの場合、APIError.networkErrorがスローされる")
+    func testFetchFortuneNetworkError() async throws {
+        struct DummyError: Error {}
+        setup(error: DummyError())
+
+        let requestDTO = FortuneRequestDTO(
+            name: "ゆめみん",
+            birthday: YMD(year: 2000, month: 1, day: 27),
+            bloodType: "ab",
+            today: YMD(year: 2000, month: 1, day: 27)
+        )
+
+        do {
+            _ = try await apiService.fetchFortune(from: requestDTO)
+            XCTFail("Expected networkError but no error was thrown")
+        } catch let error as APIError {
+            switch error {
+            case .networkError:
+                // Test passes if networkError is caught
+                break
+            default:
+                XCTFail("Expected networkError but got \(error)")
+            }
+        } catch {
+            XCTFail("Expected APIError but got \(error)")
+        }
+    }
+
+    @Test("異常系: レスポンスのデコードに失敗した場合、APIError.decodingErrorがスローされる")
+    func testFetchFortuneDecodingError() async throws {
+        let invalidJSONData = Data("invalid json".utf8)
+        setup(withResponseData: invalidJSONData)
+
+        let requestDTO = FortuneRequestDTO(
+            name: "ゆめみん",
+            birthday: YMD(year: 2000, month: 1, day: 27),
+            bloodType: "ab",
+            today: YMD(year: 2000, month: 1, day: 27)
+        )
+
+        do {
+            _ = try await apiService.fetchFortune(from: requestDTO)
+            XCTFail("Expected decodingError but no error was thrown")
+        } catch let error as APIError {
+            switch error {
+            case .decodingError:
+                // Test passes if decodingError is caught
+                break
+            default:
+                XCTFail("Expected decodingError but got \(error)")
+            }
+        } catch {
+            XCTFail("Expected APIError but got \(error)")
+        }
+    }
+}
+
+// MARK: - MockURLProtocol
+
+final class MockURLProtocol: URLProtocol {
+
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data?))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        // Handle all requests
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            fatalError("Request handler is not set.")
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data = data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {
+        // No-op
+    }
+}


### PR DESCRIPTION
## 概要

占いAPI (my_fortune) と通信を行うAPIクライアント `FortuneAPIService` を実装  
クライアントの動作を保証するための単体テストを追加

## 変更内容

- `FortuneAPIService.swift`
  - URLSession を使用して指定されたユーザー情報をもとに占いAPIへ POST リクエストを送信
  - レスポンス(JSON)をデコードして結果を返却
  - ネットワークエラーやデコードエラーなど通信時の例外をハンドリング
  - テスト容易性のため URLSession を外部注入(DI)可能な設計に変更

- `FortuneAPIServiceTests.swift`
  - MockURLProtocol を利用してネットワーク通信をモック化し FortuneAPIService の単体テストを実装
  - カバーするテストケース
    - 正常系: API通信成功時に期待通りのレスポンスが返却される
    - 異常系
      - ネットワークエラー発生時
      - レスポンスのデコード失敗時