### PR TITLE
feat: Pixabay APIから画像を検索・取得するImageServiceを実装

### DIFF
--- a/YumemiPrefectureFortune.xcodeproj/project.pbxproj
+++ b/YumemiPrefectureFortune.xcodeproj/project.pbxproj
@@ -38,9 +38,22 @@
 		701F64A02E6FD49A00495698 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		7008FA7F2E70177D00AE6C2B /* Exceptions for "YumemiPrefectureFortune" folder in "YumemiPrefectureFortune" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 700D02662E668BCA009DCF63 /* YumemiPrefectureFortune */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		700D02692E668BCA009DCF63 /* YumemiPrefectureFortune */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				7008FA7F2E70177D00AE6C2B /* Exceptions for "YumemiPrefectureFortune" folder in "YumemiPrefectureFortune" target */,
+			);
 			path = YumemiPrefectureFortune;
 			sourceTree = "<group>";
 		};
@@ -286,6 +299,7 @@
 /* Begin XCBuildConfiguration section */
 		700D02882E668BCB009DCF63 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 701F64A02E6FD49A00495698 /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -337,11 +351,13 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = YumemiPrefectureFortune/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				"OTHER_SWIFT_FLAGS[arch=*]" = "-DPIXABAY_API_KEY=\"\\\"$(PIXABAY_API_KEY)\\\"\"";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -350,6 +366,7 @@
 		};
 		700D02892E668BCB009DCF63 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 701F64A02E6FD49A00495698 /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -395,10 +412,12 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = YumemiPrefectureFortune/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
+				"OTHER_SWIFT_FLAGS[arch=*]" = "-DPIXABAY_API_KEY=\"\\\"$(PIXABAY_API_KEY)\\\"\"";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				VALIDATE_PRODUCT = YES;
@@ -407,6 +426,7 @@
 		};
 		700D028B2E668BCB009DCF63 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 701F64A02E6FD49A00495698 /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -435,6 +455,7 @@
 		};
 		700D028C2E668BCB009DCF63 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 701F64A02E6FD49A00495698 /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -463,6 +484,7 @@
 		};
 		700D028E2E668BCB009DCF63 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 701F64A02E6FD49A00495698 /* Secrets.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -482,6 +504,7 @@
 		};
 		700D028F2E668BCB009DCF63 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 701F64A02E6FD49A00495698 /* Secrets.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -501,6 +524,7 @@
 		};
 		700D02912E668BCB009DCF63 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 701F64A02E6FD49A00495698 /* Secrets.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -518,6 +542,7 @@
 		};
 		700D02922E668BCB009DCF63 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 701F64A02E6FD49A00495698 /* Secrets.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/YumemiPrefectureFortune/Info.plist
+++ b/YumemiPrefectureFortune/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PIXABAY_API_KEY</key>
+	<string>$(PIXABAY_API_KEY)</string>
+</dict>
+</plist>

--- a/YumemiPrefectureFortune/Services/ImageService.swift
+++ b/YumemiPrefectureFortune/Services/ImageService.swift
@@ -1,0 +1,149 @@
+import UIKit
+
+// MARK: - ImageServiceError
+enum ImageServiceError: Error, Equatable {
+    case invalidURL
+    case networkError(Error)
+    case badStatusCode(Int)
+    case decodingError(Error)
+    case noImageFound
+    case dataConversionError
+    
+    static func == (lhs: ImageServiceError, rhs: ImageServiceError) -> Bool {
+        switch (lhs, rhs) {
+        case (.invalidURL, .invalidURL):
+            return true
+        case (.networkError, .networkError):
+            // ErrorはEquatableではないため、ケースのみを比較
+            return true
+        case (.badStatusCode(let l), .badStatusCode(let r)):
+            return l == r
+        case (.decodingError, .decodingError):
+            // ErrorはEquatableではないため、ケースのみを比較
+            return true
+        case (.noImageFound, .noImageFound):
+            return true
+        case (.dataConversionError, .dataConversionError):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+// MARK: - Pixabay API Response DTOs
+private struct PixabayResponse: Decodable {
+    let total: Int
+    let totalHits: Int
+    let hits: [ImageHit]
+}
+
+private struct ImageHit: Decodable {
+    let webformatURL: URL
+}
+
+// MARK: - ImageServiceProtocol
+protocol ImageServiceProtocol {
+    func fetchImage(from url: URL) async throws -> UIImage
+    func searchImage(for query: String) async throws -> UIImage
+}
+
+// MARK: - ImageService
+final class ImageService: ImageServiceProtocol {
+
+    private let session: URLSession
+    private let apiKey: String
+    private let cache = NSCache<NSString, UIImage>()
+
+    /// For production use, reads the API key from the app's bundle (Info.plist).
+    init(session: URLSession = .shared, bundle: Bundle = .main) {
+        self.session = session
+        guard let apiKey = bundle.object(forInfoDictionaryKey: "PIXABAY_API_KEY") as? String, !apiKey.isEmpty else {
+            fatalError("PixabayAPIKey not found in Info.plist. Please set it up in Secrets.xcconfig and link it in the project settings.")
+        }
+        self.apiKey = apiKey
+    }
+
+    /// For testing purpose.
+    internal init(session: URLSession, apiKey: String) {
+        self.session = session
+        self.apiKey = apiKey
+    }
+
+    func fetchImage(from url: URL) async throws -> UIImage {
+
+        if let cachedImage = cache.object(forKey: url.absoluteString as NSString) {
+            return cachedImage
+        }
+
+        let (data, _) = try await handleNetworkRequest {
+            try await self.session.data(from: url)
+        }
+        
+        guard let image = UIImage(data: data) else {
+            throw ImageServiceError.dataConversionError
+        }
+
+        self.cache.setObject(image, forKey: url.absoluteString as NSString)
+
+        return image
+    }
+
+    func searchImage(for query: String) async throws -> UIImage {
+
+        guard var components = URLComponents(string: "https://pixabay.com/api/") else {
+            throw ImageServiceError.invalidURL
+        }
+        
+        components.queryItems = [
+            URLQueryItem(name: "key", value: apiKey),
+            URLQueryItem(name: "q", value: query),
+            URLQueryItem(name: "lang", value: "ja"),
+            URLQueryItem(name: "editors_choice", value: "true"),
+            URLQueryItem(name: "image_type", value: "photo"),
+            URLQueryItem(name: "orientation", value: "horizontal"),
+            URLQueryItem(name: "per_page", value: "3"), // 最初の1件だけあれば良いが範囲は3〜200なので最小の3
+        ]
+
+        guard let url = components.url else {
+            throw ImageServiceError.invalidURL
+        }
+
+        let (data, _) = try await handleNetworkRequest {
+            try await self.session.data(from: url)
+        }
+
+        do {
+            let response = try JSONDecoder().decode(PixabayResponse.self, from: data)
+            guard let firstHit = response.hits.first else {
+                throw ImageServiceError.noImageFound
+            }
+            return try await fetchImage(from: firstHit.webformatURL)
+        } catch let error as ImageServiceError {
+            throw error
+        } catch {
+            throw ImageServiceError.decodingError(error)
+        }
+    }
+    
+    private func handleNetworkRequest(
+        _ request: () async throws -> (Data, URLResponse)
+    ) async throws -> (Data, URLResponse) {
+        let data: Data
+        let response: URLResponse
+        
+        do {
+            (data, response) = try await request()
+        } catch {
+            throw ImageServiceError.networkError(error)
+        }
+        
+        guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw ImageServiceError.badStatusCode(statusCode)
+        }
+        
+        return (data, response)
+    }
+}
+


### PR DESCRIPTION
Pixabay APIと通信し指定されたクエリで画像を検索して取得する`ImageService`を追加 ## 注意点
単体テスト未実装だが**実機で取得できたので一旦よしとする**
## 主な変更点
- 指定されたクエリで画像を検索し結果のURLから画像をダウンロードする機能
- 取得した画像をメモリキャッシュに保存しネットワーク負荷を軽減する仕組み
- APIキーを`Secrets.xcconfig`で管理しビルド時に`Info.plist`経由で安全に読み込む構成