### PR TITLE
feat: プロフィール作成・編集フォームのViewModelを実装

### DIFF
--- a/YumemiPrefectureFortune/ViewModel/FortuneProfileFormViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneProfileFormViewModel.swift
@@ -67,6 +67,11 @@ final class FortuneProfileFormViewModel: ObservableObject {
             return existingProfile
         }
     }
+    
+    private func resetIcon() {
+        self.icon = nil
+        self.iconImage = nil
+    }
 enum ProfileFormMode {
     case create
     case edit(UserProfile)

--- a/YumemiPrefectureFortune/ViewModel/FortuneProfileFormViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneProfileFormViewModel.swift
@@ -3,11 +3,15 @@ import SwiftData
 
 
 final class FortuneProfileFormViewModel: ObservableObject {
+    
     @Published var name: String?
     @Published var birthday: Date?
     @Published var bloodType: BloodType?
     @Published var introduction: String?
     @Published var icon: Data?
+    
+    // 存在するなら編集、nilなら新規
+    private var existingProfile: UserProfile?
     
     init(user: UserProfile?) {
         
@@ -18,5 +22,49 @@ final class FortuneProfileFormViewModel: ObservableObject {
         self.bloodType = user.bloodType
         self.introduction = user.introduction
         self.icon = user.icon
+        
+        self.existingProfile = user
     }
+    
+    func save() throws -> UserProfile {
+        
+        // 未入力の場合を弾く
+        guard let name = name, !name.isEmpty else {
+            throw ValidationError.missingField(field: "Name")
+        }
+        
+        guard let birthday = birthday else {
+            throw ValidationError.missingField(field: "birthday")
+        }
+        
+        guard let bloodType = bloodType else {
+            throw ValidationError.missingField(field: "bloodType")
+        }
+        
+        if let existingProfile {
+            
+            existingProfile.update(name: name,
+                                   birthday: birthday,
+                                   bloodType: bloodType,
+                                   introduction: introduction,
+                                   icon: icon)
+            return existingProfile
+            
+        }else {
+            
+            let newUserProfile = UserProfile(
+                name: name,
+                birthday: birthday,
+                bloodType: bloodType,
+                introduction: introduction,
+                icon: icon
+            )
+            return newUserProfile
+
+        }
+    }
+}
+
+enum ValidationError: Error {
+    case missingField(field: String)
 }

--- a/YumemiPrefectureFortune/ViewModel/FortuneProfileFormViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneProfileFormViewModel.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PhotosUI
 import SwiftData
 
 
@@ -68,10 +69,33 @@ final class FortuneProfileFormViewModel: ObservableObject {
         }
     }
     
+    func loadIcon(from item: PhotosPickerItem?) async throws {
+        // ユーザーが選択を解除した場合、アイコンをリセットして正常終了
+        guard let item else {
+            resetIcon()
+            return
+        }
+        
+        guard let data = try await item.loadTransferable(type: Data.self) else {
+            throw IconLoadError.failedToReadItem
+        }
+        
+        guard let image = UIImage(data: data) else {
+            throw IconLoadError.dataCorrupted
+        }
+        
+        self.icon = data
+        self.iconImage = image
+        
+    }
+    
     private func resetIcon() {
         self.icon = nil
         self.iconImage = nil
     }
+
+}
+
 enum ProfileFormMode {
     case create
     case edit(UserProfile)

--- a/YumemiPrefectureFortune/ViewModel/FortuneProfileFormViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneProfileFormViewModel.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import SwiftData
+
+
+final class FortuneProfileFormViewModel: ObservableObject {
+    @Published var name: String?
+    @Published var birthday: Date?
+    @Published var bloodType: BloodType?
+    @Published var introduction: String?
+    @Published var icon: Data?
+    
+    init(user: UserProfile?) {
+        
+        guard let user else { return }
+        
+        self.name = user.name
+        self.birthday = user.birthday
+        self.bloodType = user.bloodType
+        self.introduction = user.introduction
+        self.icon = user.icon
+    }
+}

--- a/YumemiPrefectureFortuneTests/FortuneProfileFormViewModelTests.swift
+++ b/YumemiPrefectureFortuneTests/FortuneProfileFormViewModelTests.swift
@@ -1,0 +1,122 @@
+import Testing
+@testable import YumemiPrefectureFortune
+import Foundation
+
+@Suite("FortuneProfileFormViewModel Tests")
+struct FortuneProfileFormViewModelTests {
+    
+    // ベースとなるユーザー情報を生成するプライベートメソッド
+    private func makeTestUser() -> UserProfile {
+        UserProfile(
+            name: "テストユーザー",
+            birthday: Date(timeIntervalSince1970: 0),
+            bloodType: .A,
+            introduction: "よろしく",
+            icon: nil
+        )
+    }
+
+    @Test("新規作成モードでの初期化")
+    func testInitForCreateMode() {
+        let viewModel = FortuneProfileFormViewModel(user: nil)
+        
+        #expect(viewModel.name == nil)
+        #expect(viewModel.birthday == nil)
+        #expect(viewModel.bloodType == nil)
+        #expect(viewModel.introduction == nil)
+        #expect(viewModel.iconImage == nil)
+        
+        switch viewModel.mode {
+        case .create:
+            // 成功
+            break
+        case .edit:
+            Issue.record("新規作成モードのはずが、編集モードになっている")
+        }
+    }
+    
+    @Test("編集モードでの初期化")
+    func testInitForEditMode() {
+        // テストの最初に一度だけインスタンスを生成
+        let user = makeTestUser()
+        let viewModel = FortuneProfileFormViewModel(user: user)
+        
+        #expect(viewModel.name == "テストユーザー")
+        #expect(viewModel.birthday == Date(timeIntervalSince1970: 0))
+        #expect(viewModel.bloodType == .A)
+        #expect(viewModel.introduction == "よろしく")
+        
+        switch viewModel.mode {
+        case .create:
+            Issue.record("編集モードのはずが、新規作成モードになっている")
+        case .edit(let editingUser):
+            // 同じインスタンスのIDと比較する
+            #expect(editingUser.id == user.id)
+        }
+    }
+    
+    @Test("保存時のバリデーション - 名前なし")
+    func testSaveValidationForMissingName() {
+        let viewModel = FortuneProfileFormViewModel(user: nil)
+        viewModel.birthday = Date()
+        viewModel.bloodType = .B
+        
+        #expect(throws: ValidationError.self) {
+            _ = try viewModel.save()
+        }
+    }
+    
+    @Test("保存時のバリデーション - 誕生日なし")
+    func testSaveValidationForMissingBirthday() {
+        let viewModel = FortuneProfileFormViewModel(user: nil)
+        viewModel.name = "テスト"
+        viewModel.bloodType = .B
+        
+        #expect(throws: ValidationError.self) {
+            _ = try viewModel.save()
+        }
+    }
+    
+    @Test("保存時のバリデーション - 血液型なし")
+    func testSaveValidationForMissingBloodType() {
+        let viewModel = FortuneProfileFormViewModel(user: nil)
+        viewModel.name = "テスト"
+        viewModel.birthday = Date()
+        
+        #expect(throws: ValidationError.self) {
+            _ = try viewModel.save()
+        }
+    }
+    
+    @Test("新規ユーザーの保存")
+    func testSaveForNewUser() throws {
+        let viewModel = FortuneProfileFormViewModel(user: nil)
+        viewModel.name = "新しいユーザー"
+        viewModel.birthday = Date()
+        viewModel.bloodType = .O
+        viewModel.introduction = "はじめまして"
+        
+        let newUser = try viewModel.save()
+        
+        #expect(newUser.name == "新しいユーザー")
+        #expect(newUser.bloodType == .O)
+        #expect(newUser.introduction == "はじめまして")
+    }
+    
+    @Test("既存ユーザーの更新")
+    func testSaveForExistingUser() throws {
+        // テストの最初に一度だけインスタンスを生成
+        let originalUser = makeTestUser()
+        let viewModel = FortuneProfileFormViewModel(user: originalUser)
+        
+        viewModel.name = "更新されたユーザー"
+        viewModel.introduction = "更新しました"
+        
+        let updatedUser = try viewModel.save()
+        
+        // 同じインスタンスのIDと比較する
+        #expect(updatedUser.id == originalUser.id)
+        #expect(updatedUser.name == "更新されたユーザー")
+        #expect(updatedUser.introduction == "更新しました")
+    }
+}


### PR DESCRIPTION
# 主な実装内容

## ViewModelのロジック
- フォーム入力値の状態管理
- 新規 / 編集モードを判定する `ProfileFormMode` enum
- 保存時の必須項目バリデーション
- `UserProfile` モデルの作成・更新ロジック

## アイコン画像の選択
- `PhotosPicker` と連携し、選択された画像を非同期で読み込む機能

## ユニットテスト
- ViewModel の初期化、バリデーション、保存ロジックを Swift の Testing フレームワークで検証