### PR TITLE
fix: IconLoadError を LocalizedError に準拠させる

### DIFF
--- a/YumemiPrefectureFortune/ViewModel/FortuneProfileFormViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneProfileFormViewModel.swift
@@ -112,7 +112,7 @@ enum ValidationError: Error {
     }
 }
 
-enum IconLoadError: Error {
+enum IconLoadError: LocalizedError {
     case failedToReadItem
     case dataCorrupted
     


### PR DESCRIPTION
画像読み込みエラーを示す `IconLoadError` を `Error` から `LocalizedError` に変更

- `error.localizedDescription` を呼び出した際に`errorDescription` で定義したカスタムメッセージが返るように修正
  - ユーザーに表示されるアラートで意図した分かりやすいエラー文言が表示されることを保証