### PR TITLE
fix: ValidationError を LocalizedError に準拠させる

### DIFF
--- a/YumemiPrefectureFortune/ViewModel/FortuneProfileFormViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneProfileFormViewModel.swift
@@ -101,7 +101,7 @@ enum ProfileFormMode {
     case edit(UserProfile)
 }
 
-enum ValidationError: Error {
+enum ValidationError: LocalizedError {
     case missingField(field: String)
     
     var errorDescription: String? {


### PR DESCRIPTION
フォーム入力値の検証エラーを示す `ValidationError` を `LocalizedError` に変更

- 保存ボタンタップ時に表示される「入力エラー」アラートで`errorDescription` に定義した 「〇〇を入力してください」というユーザーに分かりやすいメッセージが正しく表示されるよう修正