### PR TITLE
feat: ユーザー一覧画面の実装

### DIFF
--- a/YumemiPrefectureFortune/Utils/SampleUserData.swift
+++ b/YumemiPrefectureFortune/Utils/SampleUserData.swift
@@ -1,0 +1,70 @@
+import SwiftData
+import UIKit
+import Foundation
+
+
+@MainActor
+class SampleUserData {
+    static let previewContainer: ModelContainer = {
+        do {
+            let config = ModelConfiguration(isStoredInMemoryOnly: true)
+            let container = try ModelContainer(
+                for: UserProfile.self,
+                configurations: config
+            )
+            
+            func randomBirthday() -> Date {
+                let calendar = Calendar.current
+                let year = Int.random(in: 1970...2010)
+                let month = Int.random(in: 1...12)
+                let day = Int.random(in: 1...28) // 全月対応のため28日まで
+                return calendar.date(from: DateComponents(year: year, month: month, day: day))!
+            }
+
+            let mockUsers: [UserProfile] = [
+                .init(
+                    name: "山田 太郎",
+                    birthday: randomBirthday(),
+                    bloodType: .A,
+                    introduction: "よろしくお願いします！",
+                    icon: nil
+                ),
+                .init(
+                    name: "鈴木 花子",
+                    birthday: randomBirthday(),
+                    bloodType: .B,
+                    introduction: "nil",
+                    icon: UIImage(systemName: "star.fill")?
+                        .withTintColor(.yellow, renderingMode: .alwaysOriginal)
+                        .pngData()
+                ),
+                .init(
+                    name: "佐藤 次郎",
+                    birthday: randomBirthday(),
+                    bloodType: .O,
+                    introduction: "サッカー大好き！⚽️",
+                    icon: UIImage(systemName: "heart.fill")?
+                        .withTintColor(.orange, renderingMode: .alwaysOriginal)
+                        .pngData()
+                ),
+                .init(
+                    name: "田渕 貴之",
+                    birthday: randomBirthday(),
+                    bloodType: .AB,
+                    introduction: "音楽とコーヒー☕️",
+                    icon: UIImage(systemName: "music.note")?
+                        .withTintColor(.purple, renderingMode: .alwaysOriginal)
+                        .pngData()
+                )
+            ]
+
+            mockUsers.forEach { user in
+                container.mainContext.insert(user)
+            }
+
+            return container
+        } catch {
+            fatalError("Failed to create model container for previewing: \(error.localizedDescription)")
+        }
+    }()
+}

--- a/YumemiPrefectureFortune/View/FortuneUserListView.swift
+++ b/YumemiPrefectureFortune/View/FortuneUserListView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import SwiftData
+
+struct FortuneUserListView: View {
+    @State private var isSheetPresented = false
+    
+    @Query(sort: [SortDescriptor(\UserProfile.name)]) private var users: [UserProfile]
+    
+    var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            NavigationStack {
+                List(users) { user in
+                    // TODO: 占い結果詳細画面への遷移を実装する
+                    NavigationLink(destination: Text("Detail View for \(user.name)")) {
+                        HStack(spacing: 16) {
+                            if let iconData = user.icon, let uiImage = UIImage(data: iconData) {
+                                Image(uiImage: uiImage)
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fill)
+                                    .frame(width: 44, height: 44)
+                                    .clipShape(Circle())
+                            } else {
+                                Image(systemName: "person.circle.fill")
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: 44, height: 44)
+                                    .foregroundColor(Color(UIColor.placeholderText))
+                            }
+                            Text(user.name)
+                                .font(.title3)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+                .navigationTitle("ともだちリスト")
+                .sheet(isPresented: $isSheetPresented) {
+                    FortuneProfileFormView(user: nil)
+                }
+            }
+            
+            Button(action: {
+                isSheetPresented = true
+            }) {
+                Image(systemName: "plus")
+                    .font(.title.weight(.semibold))
+                    .padding()
+                    .background(Color.accentColor)
+                    .foregroundColor(Color(UIColor.systemBackground))
+                    .clipShape(Circle())
+                    .shadow(radius: 2, x: 0, y: 4)
+            }
+            .padding()
+        }
+    }
+}
+
+#Preview("light") {
+    FortuneUserListView()
+            .modelContainer(SampleUserData.previewContainer)
+            .preferredColorScheme(.light)
+
+    
+}
+
+#Preview("dark") {
+    FortuneUserListView()
+            .modelContainer(SampleUserData.previewContainer)
+            .preferredColorScheme(.dark)
+
+    
+}

--- a/YumemiPrefectureFortune/YumemiPrefectureFortuneApp.swift
+++ b/YumemiPrefectureFortune/YumemiPrefectureFortuneApp.swift
@@ -19,7 +19,7 @@ struct YumemiPrefectureFortuneApp: App {
 
     var body: some Scene {
         WindowGroup {
-            PreviewSheetWrapper()
+            FortuneUserListView()
         }
         .modelContainer(sharedModelContainer)
     }


### PR DESCRIPTION
## 概要
アプリのメイン画面となるユーザー一覧画面 (`FortuneUserListView`) を実装  
この画面はアプリ起動時に表示され SwiftDataから取得したユーザーのリストを表示し 新規ユーザー作成画面へ遷移する機能を提供

## 主な変更点
- ユーザー一覧画面の実装 (`FortuneUserListView`)
  - `@Query` を使用してデータベースからユーザープロフィールのリストを取得し名前順で表示
  - ユーザー作成画面 (`FortuneProfileFormView`) をシート表示するためのフローティングアクションボタンを右下に配置
- アプリの初期画面設定
  - アプリ起動時のルートビューを `FortuneUserListView` に変更
- プレビュー用のデータ基盤整備
  - 複数のプレビューでサンプルデータを再利用できるよう `SampleUserData` クラスを作成しインメモリの `ModelContainer` を提供