### PR TITLE
feat: 占い詳細画面のViewModel実装と関連テストの追加

### DIFF
--- a/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+
+final class FortuneDetailViewModel: ObservableObject {
+    
+}

--- a/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
@@ -22,7 +22,32 @@ final class FortuneDetailViewModel: ObservableObject {
     
     func fetchFortuneFromAPI(for user: UserProfile) {
         isLoading = true
-        //ここでAPIを叩く
+        
+        let requestDTO = FortuneRequestDTO(user: self.user)
+        
+        Task {
+            do {
+                let result = try await apiService.fetchFortune(from: requestDTO)
+                
+                await MainActor.run {
+                    self.user.updateFortune(with: result)
+                    self.isLoading = false
+                }
+            } catch let apiError as APIError {
+                // APIエラーをハンドリング
+                await MainActor.run {
+                    // TODO: エラー内容をアラートで表示するなどの処理
+                    print("APIエラー: \\(apiError)")
+                    self.isLoading = false
+                }
+            } catch {
+                // その他の予期せぬエラー
+                await MainActor.run {
+                    print("不明なエラー: \\(error)")
+                    self.isLoading = false
+                }
+            }
+            
+        }
     }
-    
 }

--- a/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
@@ -9,9 +9,14 @@ final class FortuneDetailViewModel: ObservableObject {
     @Published var headerImage: UIImage?
     @Published var isLoading: Bool
     
-    init(user: UserProfile) {
+    private let apiService: FortuneAPIServiceProtocol
+    private let imageService: ImageServiceProtocol
+    
+    init(user: UserProfile, apiService: FortuneAPIServiceProtocol = FortuneAPIService(), imageService: ImageServiceProtocol = ImageService()) {
         self.user = user
         self.isLoading = false
+        self.apiService = apiService
+        self.imageService = imageService
         fetchFortuneFromAPI(for: user)
     }
     

--- a/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
@@ -33,6 +33,10 @@ final class FortuneDetailViewModel: ObservableObject {
                     self.user.updateFortune(with: result)
                     self.isLoading = false
                 }
+                
+                await fetchLogoImage(from: result.prefecture.logoUrl)
+                await fetchHeaderImage(query: result.prefecture.name)
+                
             } catch let apiError as APIError {
                 // APIエラーをハンドリング
                 await MainActor.run {
@@ -47,7 +51,6 @@ final class FortuneDetailViewModel: ObservableObject {
                     self.isLoading = false
                 }
             }
-            
         }
     }
     

--- a/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
@@ -33,9 +33,12 @@ final class FortuneDetailViewModel: ObservableObject {
                     self.user.updateFortune(with: result)
                     self.isLoading = false
                 }
+                /// asyncに変更することで並列に処理をするように
+                async let logoImageTask: () = fetchLogoImage(from: result.prefecture.logoUrl)
+                async let headerImageTask: () = fetchHeaderImage(query: result.prefecture.name)
                 
-                await fetchLogoImage(from: result.prefecture.logoUrl)
-                await fetchHeaderImage(query: result.prefecture.name)
+                await logoImageTask
+                await headerImageTask
                 
             } catch let apiError as APIError {
                 // APIエラーをハンドリング

--- a/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
@@ -52,10 +52,24 @@ final class FortuneDetailViewModel: ObservableObject {
     }
     
     private func fetchLogoImage(from url: URL) async {
-        
+        do {
+            let image = try await imageService.fetchImage(from: url)
+            await MainActor.run {
+                self.logoImage = image
+            }
+        } catch {
+            print("ロゴ画像の取得に失敗しました: \(error.localizedDescription)")
+        }
     }
     
     private func fetchHeaderImage(query: String) async {
-        
+        do {
+            let image = try await imageService.searchImage(for: query)
+            await MainActor.run {
+                self.headerImage = image
+            }
+        } catch {
+            print("ヘッダー画像の取得に失敗しました: \(error.localizedDescription)")
+        }
     }
 }

--- a/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
@@ -1,6 +1,17 @@
 import Foundation
+import UIKit
 
 
 final class FortuneDetailViewModel: ObservableObject {
+    
+    @Published var user: UserProfile
+    @Published var logoImage: UIImage?
+    @Published var headerImage: UIImage?
+    @Published var isLoading: Bool
+    
+    init(user: UserProfile) {
+        self.user = user
+        self.isLoading = false
+    }
     
 }

--- a/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
@@ -12,6 +12,12 @@ final class FortuneDetailViewModel: ObservableObject {
     init(user: UserProfile) {
         self.user = user
         self.isLoading = false
+        fetchFortuneFromAPI(for: user)
+    }
+    
+    func fetchFortuneFromAPI(for user: UserProfile) {
+        isLoading = true
+        //ここでAPIを叩く
     }
     
 }

--- a/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
@@ -50,4 +50,12 @@ final class FortuneDetailViewModel: ObservableObject {
             
         }
     }
+    
+    private func fetchLogoImage(from url: URL) async {
+        
+    }
+    
+    private func fetchHeaderImage(query: String) async {
+        
+    }
 }

--- a/YumemiPrefectureFortuneTests/FortuneDetailViewModelTests.swift
+++ b/YumemiPrefectureFortuneTests/FortuneDetailViewModelTests.swift
@@ -1,0 +1,122 @@
+
+import Testing
+import Foundation
+import UIKit
+@testable import YumemiPrefectureFortune
+
+// MARK: - Mock Services
+
+/// 占いAPIサービスのためのモック
+struct MockFortuneAPIService: FortuneAPIServiceProtocol {
+    var result: Result<FortuneResult, APIError>
+
+    func fetchFortune(from request: FortuneRequestDTO) async throws -> FortuneResult {
+        // 呼び出しを0.1秒遅延させて、非同期処理をシミュレート
+        try await Task.sleep(nanoseconds: 100_000_000)
+        return try result.get()
+    }
+}
+
+/// 画像取得サービスのためのモック
+struct MockImageService: ImageServiceProtocol {
+    var fetchImageResult: Result<UIImage, Error>
+    var searchImageResult: Result<UIImage, Error>
+
+    // ダミーのUIImageインスタンスを生成
+    static let dummyImage = UIImage(systemName: "star")!
+    // ダミーのエラー
+    struct DummyError: Error {}
+
+    func fetchImage(from url: URL) async throws -> UIImage {
+        return try fetchImageResult.get()
+    }
+
+    func searchImage(for query: String) async throws -> UIImage {
+        return try searchImageResult.get()
+    }
+}
+
+@Suite("FortuneDetailViewModel Tests")
+struct FortuneDetailViewModelTests {
+
+    var viewModel: FortuneDetailViewModel!
+    var user: UserProfile!
+    var mockAPIService: MockFortuneAPIService!
+    var mockImageService: MockImageService!
+
+    init() {
+        // テストで使用するベースのユーザーを準備
+        user = UserProfile(name: "テストユーザー", birthday: Date(), bloodType: .A, introduction: nil, icon: nil)
+    }
+
+    @Test("正常系: 占いと画像取得がすべて成功する")
+    @MainActor
+    mutating func testFetchAllSuccess() async throws {
+        // --- 準備 ---
+        let prefecture = Prefecture(name: "沖縄県", capital: "那覇市", citizenDay: nil, logoUrl: URL(string: "https://example.com")!, brief: "", hasCoastLine: true)
+        let fortuneResult = FortuneResult(prefecture: prefecture)
+
+        mockAPIService = MockFortuneAPIService(result: .success(fortuneResult))
+        mockImageService = MockImageService(fetchImageResult: .success(MockImageService.dummyImage), searchImageResult: .success(MockImageService.dummyImage))
+
+        // --- 実行 ---
+        viewModel = FortuneDetailViewModel(user: user, apiService: mockAPIService, imageService: mockImageService)
+
+        // --- 検証 ---
+        // 初期化直後はローディング中のはず
+        #expect(self.viewModel.isLoading == true)
+
+        // 非同期処理の完了を待つ（APIのモックで0.1秒遅延させているため、それ以上待つ）
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // 最終的な状態を検証
+        #expect(self.viewModel.isLoading == false)
+        #expect(self.viewModel.user.fortuneResult?.prefecture.name == "沖縄県")
+        #expect(self.viewModel.logoImage != nil)
+        #expect(self.viewModel.headerImage != nil)
+    }
+
+    @Test("異常系: 占いAPIがエラーを返す")
+    @MainActor
+    mutating func testFetchFortuneAPIFailure() async throws {
+        // --- 準備 ---
+        mockAPIService = MockFortuneAPIService(result: .failure(.networkError(URLError(.notConnectedToInternet))))
+        mockImageService = MockImageService(fetchImageResult: .success(MockImageService.dummyImage), searchImageResult: .success(MockImageService.dummyImage))
+
+        // --- 実行 ---
+        viewModel = FortuneDetailViewModel(user: user, apiService: mockAPIService, imageService: mockImageService)
+
+        // --- 検証 ---
+        #expect(self.viewModel.isLoading == true)
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        #expect(self.viewModel.isLoading == false)
+        #expect(self.viewModel.user.fortuneResult == nil) // 占い結果はnilのまま
+        #expect(self.viewModel.logoImage == nil)      // 画像取得処理は実行されない
+        #expect(self.viewModel.headerImage == nil)
+    }
+
+    @Test("異常系: ロゴ画像の取得に失敗する")
+    @MainActor
+    mutating func testFetchLogoImageFailure() async throws {
+        // --- 準備 ---
+        let prefecture = Prefecture(name: "沖縄県", capital: "那覇市", citizenDay: nil, logoUrl: URL(string: "https://example.com")!, brief: "", hasCoastLine: true)
+        let fortuneResult = FortuneResult(prefecture: prefecture)
+
+        mockAPIService = MockFortuneAPIService(result: .success(fortuneResult))
+        // ロゴ画像取得のみ失敗させる
+        mockImageService = MockImageService(fetchImageResult: .failure(MockImageService.DummyError()), searchImageResult: .success(MockImageService.dummyImage))
+
+        // --- 実行 ---
+        viewModel = FortuneDetailViewModel(user: user, apiService: mockAPIService, imageService: mockImageService)
+
+        // --- 検証 ---
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        #expect(self.viewModel.isLoading == false)
+        #expect(self.viewModel.user.fortuneResult != nil)
+        #expect(self.viewModel.logoImage == nil) // ロゴ画像はnil
+        #expect(self.viewModel.headerImage != nil) // ヘッダー画像は成功
+    }
+}


### PR DESCRIPTION
## 概要

- 占い詳細画面（FortuneDetailView）のビジネスロジックを担当するFortuneDetailViewModelを実装
- 関連するテストを追加・修正

## 主な変更点

- FortuneDetailViewModelの実装
  - init時に占いAPIと画像APIを非同期で呼び出し、占い結果・ロゴ画像・ヘッダー画像を取得
  - API通信中や画像取得中の状態を管理するisLoadingプロパティを実装
  - APIサービスと画像サービスを外部から注入（DI）できる設計にし、テスト容易性を向上

- パフォーマンス改善
  - ロゴ画像とヘッダー画像の取得処理をasync letで並列化し、表示速度を向上

- テストの追加
  - FortuneDetailViewModelのロジックを検証するユニットテストを追加（正常系・異常系）