### PR TITLE
refactor: 占い結果をViewModelから直接公開するように変更

### DIFF
--- a/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
@@ -5,6 +5,7 @@ import UIKit
 final class FortuneDetailViewModel: ObservableObject {
     
     @Published var user: UserProfile
+    @Published var fortune: FortuneResult?
     @Published var logoImage: UIImage?
     @Published var headerImage: UIImage?
     @Published var isLoading: Bool
@@ -28,6 +29,7 @@ final class FortuneDetailViewModel: ObservableObject {
         Task {
             do {
                 let result = try await apiService.fetchFortune(from: requestDTO)
+                fortune = result
                 
                 await MainActor.run {
                     self.user.updateFortune(with: result)


### PR DESCRIPTION
`FortuneDetailViewModel`に`@Published`な`fortune`プロパティを追加し占い結果をViewModelから直接Viewに公開