### PR TITLE
refactor: UI更新をMainActorで保証

### DIFF
--- a/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
@@ -29,9 +29,9 @@ final class FortuneDetailViewModel: ObservableObject {
         Task {
             do {
                 let result = try await apiService.fetchFortune(from: requestDTO)
-                fortune = result
                 
                 await MainActor.run {
+                    self.fortune = result
                     self.user.updateFortune(with: result)
                     self.isLoading = false
                 }

--- a/YumemiPrefectureFortune/ViewModel/FortuneProfileFormViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneProfileFormViewModel.swift
@@ -72,7 +72,7 @@ final class FortuneProfileFormViewModel: ObservableObject {
     func loadIcon(from item: PhotosPickerItem?) async throws {
         // ユーザーが選択を解除した場合、アイコンをリセットして正常終了
         guard let item else {
-            resetIcon()
+            await resetIcon()
             return
         }
         
@@ -84,11 +84,13 @@ final class FortuneProfileFormViewModel: ObservableObject {
             throw IconLoadError.dataCorrupted
         }
         
-        self.icon = data
-        self.iconImage = image
-        
+        await MainActor.run {
+            self.icon = data
+            self.iconImage = image
+        }
     }
     
+    @MainActor
     private func resetIcon() {
         self.icon = nil
         self.iconImage = nil


### PR DESCRIPTION
ViewModelからUIにバインドされているプロパティ更新をすべてメインスレッドで安全に実行されるよう修正

- FortuneDetailViewModel
  - fetchFortune内で占い結果の代入をMainActor.runブロック内に移動
- FortuneProfileFormViewModel
  - loadIcon内で取得したアイコン画像の代入をMainActor.runブロック内に移動
  - resetIconメソッドに@MainActorアノテーションを追加