### PR TITLE
fix: ユーザーリスト画面のナビゲーションを修正

### DIFF
--- a/YumemiPrefectureFortune/View/FortuneUserListView.swift
+++ b/YumemiPrefectureFortune/View/FortuneUserListView.swift
@@ -7,51 +7,52 @@ struct FortuneUserListView: View {
     @Query(sort: [SortDescriptor(\UserProfile.name)]) private var users: [UserProfile]
     
     var body: some View {
-        ZStack(alignment: .bottomTrailing) {
-            NavigationStack {
+        NavigationStack {
+            ZStack(alignment: .bottomTrailing) {
+                
                 List(users) { user in
-                    // TODO: 占い結果詳細画面への遷移を実装する
-                    NavigationLink(destination: Text("Detail View for \(user.name)")) {
-                        HStack(spacing: 16) {
-                            if let iconData = user.icon, let uiImage = UIImage(data: iconData) {
-                                Image(uiImage: uiImage)
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                                    .frame(width: 44, height: 44)
-                                    .clipShape(Circle())
-                            } else {
-                                Image(systemName: "person.circle.fill")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 44, height: 44)
-                                    .foregroundColor(Color(UIColor.placeholderText))
+                    NavigationLink(
+                        destination:FortuneDetailView(viewModel: FortuneDetailViewModel(user: user))) {
+                            HStack(spacing: 16) {
+                                if let iconData = user.icon, let uiImage = UIImage(data: iconData) {
+                                    Image(uiImage: uiImage)
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fill)
+                                        .frame(width: 44, height: 44)
+                                        .clipShape(Circle())
+                                } else {
+                                    Image(systemName: "person.circle.fill")
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: 44, height: 44)
+                                        .foregroundColor(Color(UIColor.placeholderText))
+                                }
+                                Text(user.name)
+                                    .font(.title3)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
                             }
-                            Text(user.name)
-                                .font(.title3)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
+                            .padding(.vertical, 4)
                         }
-                        .padding(.vertical, 4)
-                    }
                 }
                 .navigationTitle("ともだちリスト")
                 .sheet(isPresented: $isSheetPresented) {
                     FortuneProfileFormView(user: nil)
                 }
+                
+                Button(action: {
+                    isSheetPresented = true
+                }) {
+                    Image(systemName: "plus")
+                        .font(.title.weight(.semibold))
+                        .padding()
+                        .background(Color.accentColor)
+                        .foregroundColor(Color(UIColor.systemBackground))
+                        .clipShape(Circle())
+                        .shadow(radius: 2, x: 0, y: 4)
+                }
+                .padding()
             }
-            
-            Button(action: {
-                isSheetPresented = true
-            }) {
-                Image(systemName: "plus")
-                    .font(.title.weight(.semibold))
-                    .padding()
-                    .background(Color.accentColor)
-                    .foregroundColor(Color(UIColor.systemBackground))
-                    .clipShape(Circle())
-                    .shadow(radius: 2, x: 0, y: 4)
-            }
-            .padding()
         }
     }
 }


### PR DESCRIPTION
FortuneUserListViewでの画面遷移の問題を修正し正しい遷移動作を実装

- 詳細画面遷移時に背後に残っていたプラスボタンを解消
  - ZStackとNavigationStackの階層を修正しボタンがナビゲーション管理下に入るよう変更
- リスト項目タップ時の遷移先を仮のテキストから`FortuneDetailView`に変更