### PR TITLE
  feat: 占い詳細画面の実装

### DIFF
--- a/YumemiPrefectureFortune.xcodeproj/project.pbxproj
+++ b/YumemiPrefectureFortune.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		701F649F2E6FD49400495698 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 701F649E2E6FD49400495698 /* README.md */; };
 		701F64A12E6FD49A00495698 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 701F64A02E6FD49A00495698 /* Secrets.xcconfig */; };
 		70B34AA42E755ACA00C58479 /* FortuneProfileFormViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B34AA22E755ACA00C58479 /* FortuneProfileFormViewUITests.swift */; };
+		70E96D242E782215000BB6FF /* FortuneDetailViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E96D232E782215000BB6FF /* FortuneDetailViewUITests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,6 +39,7 @@
 		701F649E2E6FD49400495698 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		701F64A02E6FD49A00495698 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		70B34AA22E755ACA00C58479 /* FortuneProfileFormViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FortuneProfileFormViewUITests.swift; sourceTree = "<group>"; };
+		70E96D232E782215000BB6FF /* FortuneDetailViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FortuneDetailViewUITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -118,6 +120,7 @@
 			isa = PBXGroup;
 			children = (
 				70B34AA22E755ACA00C58479 /* FortuneProfileFormViewUITests.swift */,
+				70E96D232E782215000BB6FF /* FortuneDetailViewUITests.swift */,
 			);
 			path = YumemiPrefectureFortuneUITests;
 			sourceTree = "<group>";
@@ -281,6 +284,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				70B34AA42E755ACA00C58479 /* FortuneProfileFormViewUITests.swift in Sources */,
+				70E96D242E782215000BB6FF /* FortuneDetailViewUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/YumemiPrefectureFortune/Utils/SampleUserData.swift
+++ b/YumemiPrefectureFortune/Utils/SampleUserData.swift
@@ -5,6 +5,13 @@ import Foundation
 
 @MainActor
 class SampleUserData {
+    
+    static let sampleUser: UserProfile = UserProfile(name: "山田 太郎",
+                                                     birthday: Date(),
+                                                     bloodType: .A,
+                                                     introduction: "よろしくお願いします！\n趣味はハイキングとフィッシング詐欺です。",
+                                                     icon: nil)
+    
     static let previewContainer: ModelContainer = {
         do {
             let config = ModelConfiguration(isStoredInMemoryOnly: true)

--- a/YumemiPrefectureFortune/View/FortuneDetailView.swift
+++ b/YumemiPrefectureFortune/View/FortuneDetailView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct FortuneDetailView: View {
     @StateObject var viewModel: FortuneDetailViewModel
+    @State var isSheetPresented = false
     
     var body: some View {
         // TODO: 背景色はプレースホルダーの段階で見やすくするためだけなので実装時は削除
@@ -28,6 +29,7 @@ struct FortuneDetailView: View {
                         .resizable()
                         .aspectRatio(contentMode: .fill)
                         .frame(width: 80, height: 80)
+                        .background(.background)
                         .clipShape(Circle())
                         .padding(.top, -40)
                         .padding(.leading, 20)
@@ -44,7 +46,7 @@ struct FortuneDetailView: View {
                 }
                 Spacer()
                 Button(action: {
-                    // 編集ボタンを押したときの処理
+                    isSheetPresented = true
                 }) {
                     Text("編集")
                         .font(.system(size: 14, weight: .medium))
@@ -104,9 +106,13 @@ struct FortuneDetailView: View {
                             Text(result.prefecture.name)
                                 .font(.system(size: 50, weight: .bold))
                                 .frame(maxWidth: .infinity, alignment: .leading)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.5)
                             Text(result.prefecture.capital)
                                 .font(.system(size: 35, weight: .medium))
-                                .frame(maxWidth: .infinity, alignment: .center)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.5)
                             Spacer()
                         }
                         if let iconImage = viewModel.logoImage {
@@ -156,6 +162,9 @@ struct FortuneDetailView: View {
             }
         }
         .ignoresSafeArea(edges: .top)
+        .sheet(isPresented: $isSheetPresented) {
+            FortuneProfileFormView(user: viewModel.user)
+        }
     }
     
     func formatDate(_ date: Date) -> String {

--- a/YumemiPrefectureFortune/View/FortuneDetailView.swift
+++ b/YumemiPrefectureFortune/View/FortuneDetailView.swift
@@ -2,6 +2,123 @@ import SwiftUI
 
 struct FortuneDetailView: View {
     var body: some View {
+        // TODO: 背景色はプレースホルダーの段階で見やすくするためだけなので実装時は削除
+        ScrollView {
+            Image("")
+                .resizable()
+                .frame(height: 200)
+                .background(.green)
+
+            HStack {
+                Image("")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 80, height: 80)
+                    .background(.red)
+                    .clipShape(Circle())
+                    .padding(.top, -40)
+                    .padding(.leading, 20)
+                Spacer()
+                Button(action: {
+                    // 編集ボタンを押したときの処理
+                }) {
+                    Text("編集")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(.primary)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .overlay(
+                                RoundedRectangle(cornerRadius: 20)
+                                    .stroke(Color.gray, lineWidth: 2)
+                            )
+                    
+                }
+                .padding(.trailing, 20)
+            }
+            
+            Text("名前")
+                .font(.system(size: 32, weight: .semibold))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 20)
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+            
+            HStack {
+                Spacer()
+                Text("X型")
+                    .font(.system(size: 16, weight: .medium))
+                    .lineLimit(1)
+                /// gift.fillは誕生日のアイコンとする
+                /// birthdaycakeは複雑すぎて今回のサイズでは視認性が悪いため却下
+                Image(systemName: "gift.fill")
+                    .scaleEffect(0.8)
+                    .padding(.leading, 20)
+                    .padding(.trailing, -8)
+
+                Text("YYYY/MM/DD")
+                    .font(.system(size: 16, weight: .medium))
+                    .padding(.trailing, 20)
+                    .lineLimit(1)
+            }
+            .padding(.bottom, 8)
+            Text("自己紹介\n2行目\n3行目\n4行目")
+                .font(.system(size: 12, weight: .regular))
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 20)
+            /// 高さを取りすぎないように4行に制限
+                .lineLimit(4)
+            
+            
+            VStack {
+                VStack(spacing: 16) {
+                    Text("今日の都道府県")
+                        .font(.system(size: 32, weight: .semibold))
+                    
+                    HStack {
+                        VStack {
+                            Spacer()
+                            Text("XX県")
+                                .font(.system(size: 50, weight: .bold))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            Text("xx市")
+                                .font(.system(size: 35, weight: .medium))
+                                .frame(maxWidth: .infinity, alignment: .center)
+                            Spacer()
+                        }
+                        Image("")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 100, height: 100)
+                            .background(.red)
+                            .clipShape(Circle())
+                        
+                    }
+                    
+                    Text("Wikipediaによる概要")
+                        .font(.system(size: 16, weight: .regular))
+                        .foregroundColor(.secondary)
+
+                    HStack {
+                        Text("県民の日")
+                            .font(.system(size: 35, weight: .semibold))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Text("MM/DD")
+                            .font(.system(size: 35, weight: .semibold))
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                    Text("内陸／海沿い")
+                        .font(.system(size: 32, weight: .semibold))
+                }
+                .padding(.horizontal, 30)
+                .padding(.vertical, 16)
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .background(Color.yellow)
+            .cornerRadius(20)
+            .padding(20)
+        }
+        .ignoresSafeArea(edges: .top)
     }
 }
 

--- a/YumemiPrefectureFortune/View/FortuneDetailView.swift
+++ b/YumemiPrefectureFortune/View/FortuneDetailView.swift
@@ -10,16 +10,27 @@ struct FortuneDetailView: View {
                 .resizable()
                 .frame(height: 200)
                 .background(.green)
-
+            
             HStack {
-                Image("")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 80, height: 80)
-                    .background(.red)
-                    .clipShape(Circle())
-                    .padding(.top, -40)
-                    .padding(.leading, 20)
+                if let iconData = viewModel.user.icon, let uiImage = UIImage(data: iconData) {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: 80, height: 80)
+                        .clipShape(Circle())
+                        .padding(.top, -40)
+                        .padding(.leading, 20)
+                } else {
+                    Image(systemName: "person.circle.fill")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 80, height: 80)
+                        .foregroundColor(Color(UIColor.placeholderText))
+                        .background()
+                        .clipShape(Circle())
+                        .padding(.top, -40)
+                        .padding(.leading, 20)
+                }
                 Spacer()
                 Button(action: {
                     // 編集ボタンを押したときの処理
@@ -30,15 +41,15 @@ struct FortuneDetailView: View {
                         .padding(.horizontal, 16)
                         .padding(.vertical, 8)
                         .overlay(
-                                RoundedRectangle(cornerRadius: 20)
-                                    .stroke(Color.gray, lineWidth: 2)
-                            )
+                            RoundedRectangle(cornerRadius: 20)
+                                .stroke(Color.gray, lineWidth: 2)
+                        )
                     
                 }
                 .padding(.trailing, 20)
             }
             
-            Text("名前")
+            Text(viewModel.user.name)
                 .font(.system(size: 32, weight: .semibold))
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 20)
@@ -47,7 +58,7 @@ struct FortuneDetailView: View {
             
             HStack {
                 Spacer()
-                Text("X型")
+                Text(viewModel.user.bloodType.displayName + "型")
                     .font(.system(size: 16, weight: .medium))
                     .lineLimit(1)
                 /// gift.fillは誕生日のアイコンとする
@@ -56,14 +67,14 @@ struct FortuneDetailView: View {
                     .scaleEffect(0.8)
                     .padding(.leading, 20)
                     .padding(.trailing, -8)
-
-                Text("YYYY/MM/DD")
+                
+                Text(formatDate(viewModel.user.birthday))
                     .font(.system(size: 16, weight: .medium))
                     .padding(.trailing, 20)
                     .lineLimit(1)
             }
             .padding(.bottom, 8)
-            Text("自己紹介\n2行目\n3行目\n4行目")
+            Text(viewModel.user.introduction ?? "")
                 .font(.system(size: 12, weight: .regular))
                 .foregroundColor(.secondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -121,6 +132,12 @@ struct FortuneDetailView: View {
             .padding(20)
         }
         .ignoresSafeArea(edges: .top)
+    }
+    
+    func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy/M/d"
+        return formatter.string(from: date)
     }
 }
 

--- a/YumemiPrefectureFortune/View/FortuneDetailView.swift
+++ b/YumemiPrefectureFortune/View/FortuneDetailView.swift
@@ -94,55 +94,65 @@ struct FortuneDetailView: View {
                 .lineLimit(4)
             
             if let result = viewModel.user.fortuneResult {
-                
-            } else {
-                VStack {
-                    VStack(spacing: 16) {
-                        Text("今日の都道府県")
-                            .font(.system(size: 32, weight: .semibold))
-                        
-                        HStack {
-                            VStack {
-                                Spacer()
-                                Text("XX県")
-                                    .font(.system(size: 50, weight: .bold))
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                Text("xx市")
-                                    .font(.system(size: 35, weight: .medium))
-                                    .frame(maxWidth: .infinity, alignment: .center)
-                                Spacer()
-                            }
-                            Image("")
+                VStack(spacing: 16) {
+                    Text("今日の都道府県")
+                        .font(.system(size: 32, weight: .semibold))
+                    
+                    HStack {
+                        VStack {
+                            Spacer()
+                            Text(result.prefecture.name)
+                                .font(.system(size: 50, weight: .bold))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            Text(result.prefecture.capital)
+                                .font(.system(size: 35, weight: .medium))
+                                .frame(maxWidth: .infinity, alignment: .center)
+                            Spacer()
+                        }
+                        if let iconImage = viewModel.logoImage {
+                            Image(uiImage: iconImage)
                                 .resizable()
                                 .aspectRatio(contentMode: .fit)
                                 .frame(width: 100, height: 100)
-                                .background(.red)
                                 .clipShape(Circle())
-                            
+                        } else {
+                            Circle()
+                                .fill(.clear)
+                                .frame(width: 100, height: 100)
+                                .overlay {
+                                    ProgressView()
+                                }
                         }
-                        
-                        Text("Wikipediaによる概要")
-                            .font(.system(size: 16, weight: .regular))
-                            .foregroundColor(.secondary)
-                        
+                    }
+                    
+                    Text(result.prefecture.brief)
+                        .font(.system(size: 16, weight: .regular))
+                        .foregroundColor(.secondary)
+                    
+                    if let citizenDay = result.prefecture.citizenDay {
                         HStack {
                             Text("県民の日")
                                 .font(.system(size: 35, weight: .semibold))
                                 .frame(maxWidth: .infinity, alignment: .leading)
-                            Text("MM/DD")
+                            Text(formatMonthDay(citizenDay))
                                 .font(.system(size: 35, weight: .semibold))
                                 .frame(maxWidth: .infinity, alignment: .trailing)
                         }
-                        Text("内陸／海沿い")
-                            .font(.system(size: 32, weight: .semibold))
                     }
-                    .padding(.horizontal, 30)
-                    .padding(.vertical, 16)
+                    Text(result.prefecture.hasCoastLine ? "海沿い" : "内陸")
+                        .font(.system(size: 32, weight: .semibold))
+                        .foregroundColor(.secondary)
                 }
+                .padding(.horizontal, 30)
+                .padding(.vertical, 16)
                 .frame(maxWidth: .infinity, alignment: .center)
-                .background(Color.yellow)
+                .background(.background)
                 .cornerRadius(20)
                 .padding(20)
+                .shadow(color:.primary.opacity(0.4), radius: 10, x: 0, y: 4)
+            } else {
+                ProgressView()
+                    .padding(30)
             }
         }
         .ignoresSafeArea(edges: .top)
@@ -152,6 +162,10 @@ struct FortuneDetailView: View {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy/M/d"
         return formatter.string(from: date)
+    }
+    
+    func formatMonthDay(_ monthDay: MonthDay) -> String {
+        return("\(monthDay.month)/\(monthDay.day)")
     }
 }
 

--- a/YumemiPrefectureFortune/View/FortuneDetailView.swift
+++ b/YumemiPrefectureFortune/View/FortuneDetailView.swift
@@ -62,6 +62,7 @@ struct FortuneDetailView: View {
                         
                     }
                     .padding(.trailing, 20)
+                    .accessibilityIdentifier("editButton")
                 }
                 
                 Text(viewModel.user.name)
@@ -70,6 +71,7 @@ struct FortuneDetailView: View {
                     .padding(.horizontal, 20)
                     .lineLimit(1)
                     .minimumScaleFactor(0.5)
+                    .accessibilityIdentifier("userNameText")
                 
                 HStack {
                     Spacer()
@@ -110,6 +112,7 @@ struct FortuneDetailView: View {
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                     .lineLimit(1)
                                     .minimumScaleFactor(0.5)
+                                    .accessibilityIdentifier("prefectureNameText")
                                 Text(result.prefecture.capital)
                                     .font(.system(size: 35, weight: .medium))
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -161,6 +164,7 @@ struct FortuneDetailView: View {
                 } else {
                     ProgressView()
                         .padding(30)
+                        .accessibilityIdentifier("loadingIndicator")
                 }
             }
             .ignoresSafeArea(edges: .top)
@@ -182,6 +186,7 @@ struct FortuneDetailView: View {
             .padding()
             .padding(.top, 20)
             .ignoresSafeArea(edges: .top)
+            .accessibilityIdentifier("backButton")
 
         }
         .navigationBarHidden(true)

--- a/YumemiPrefectureFortune/View/FortuneDetailView.swift
+++ b/YumemiPrefectureFortune/View/FortuneDetailView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct FortuneDetailView: View {
+    @StateObject var viewModel: FortuneDetailViewModel
+    
     var body: some View {
         // TODO: 背景色はプレースホルダーの段階で見やすくするためだけなので実装時は削除
         ScrollView {
@@ -123,15 +125,13 @@ struct FortuneDetailView: View {
 }
 
 #Preview("light") {
-    FortuneDetailView()
-            .preferredColorScheme(.light)
-
-    
+    let viewModel = FortuneDetailViewModel(user: SampleUserData.sampleUser)
+    FortuneDetailView(viewModel: viewModel)
+        .preferredColorScheme(.light)
 }
 
 #Preview("dark") {
-    FortuneDetailView()
-            .preferredColorScheme(.dark)
-
-    
+    let viewModel = FortuneDetailViewModel(user: SampleUserData.sampleUser)
+    FortuneDetailView(viewModel: viewModel)
+        .preferredColorScheme(.dark)
 }

--- a/YumemiPrefectureFortune/View/FortuneDetailView.swift
+++ b/YumemiPrefectureFortune/View/FortuneDetailView.swift
@@ -1,170 +1,190 @@
 import SwiftUI
 
 struct FortuneDetailView: View {
+    @Environment(\.dismiss) private var dismiss
+    
     @StateObject var viewModel: FortuneDetailViewModel
     @State var isSheetPresented = false
     
     var body: some View {
-        // TODO: 背景色はプレースホルダーの段階で見やすくするためだけなので実装時は削除
-        ScrollView {
-            if let headerImage = viewModel.headerImage {
-                Image(uiImage: headerImage)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(height: 180)
-                    .clipped()
-            } else {
-                // 画像読み込み中のプレースホルダー
-                Rectangle()
-                    .fill(Color(UIColor.systemGray4))
-                    .frame(height: 180)
-                    .overlay {
-                        ProgressView()
-                            .padding(.top, 40)
-                    }
-            }
-            HStack {
-                if let iconData = viewModel.user.icon, let uiImage = UIImage(data: iconData) {
-                    Image(uiImage: uiImage)
+        ZStack(alignment: .topLeading) {
+            ScrollView {
+                if let headerImage = viewModel.headerImage {
+                    Image(uiImage: headerImage)
                         .resizable()
                         .aspectRatio(contentMode: .fill)
-                        .frame(width: 80, height: 80)
-                        .background(.background)
-                        .clipShape(Circle())
-                        .padding(.top, -40)
-                        .padding(.leading, 20)
+                        .frame(height: 180)
+                        .clipped()
                 } else {
-                    Image(systemName: "person.circle.fill")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 80, height: 80)
-                        .foregroundColor(Color(UIColor.placeholderText))
-                        .background()
-                        .clipShape(Circle())
-                        .padding(.top, -40)
-                        .padding(.leading, 20)
+                    // 画像読み込み中のプレースホルダー
+                    Rectangle()
+                        .fill(Color(UIColor.systemGray4))
+                        .frame(height: 180)
+                        .overlay {
+                            ProgressView()
+                                .padding(.top, 40)
+                        }
                 }
-                Spacer()
-                Button(action: {
-                    isSheetPresented = true
-                }) {
-                    Text("編集")
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundColor(.primary)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 8)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 20)
-                                .stroke(Color.gray, lineWidth: 2)
-                        )
-                    
-                }
-                .padding(.trailing, 20)
-            }
-            
-            Text(viewModel.user.name)
-                .font(.system(size: 32, weight: .semibold))
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 20)
-                .lineLimit(1)
-                .minimumScaleFactor(0.5)
-            
-            HStack {
-                Spacer()
-                Text(viewModel.user.bloodType.displayName + "型")
-                    .font(.system(size: 16, weight: .medium))
-                    .lineLimit(1)
-                /// gift.fillは誕生日のアイコンとする
-                /// birthdaycakeは複雑すぎて今回のサイズでは視認性が悪いため却下
-                Image(systemName: "gift.fill")
-                    .scaleEffect(0.8)
-                    .padding(.leading, 20)
-                    .padding(.trailing, -8)
-                
-                Text(formatDate(viewModel.user.birthday))
-                    .font(.system(size: 16, weight: .medium))
+                HStack {
+                    if let iconData = viewModel.user.icon, let uiImage = UIImage(data: iconData) {
+                        Image(uiImage: uiImage)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: 80, height: 80)
+                            .background(.background)
+                            .clipShape(Circle())
+                            .padding(.top, -40)
+                            .padding(.leading, 20)
+                    } else {
+                        Image(systemName: "person.circle.fill")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 80, height: 80)
+                            .foregroundColor(Color(UIColor.placeholderText))
+                            .background()
+                            .clipShape(Circle())
+                            .padding(.top, -40)
+                            .padding(.leading, 20)
+                    }
+                    Spacer()
+                    Button(action: {
+                        isSheetPresented = true
+                    }) {
+                        Text("編集")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(.primary)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 20)
+                                    .stroke(Color.gray, lineWidth: 2)
+                            )
+                        
+                    }
                     .padding(.trailing, 20)
-                    .lineLimit(1)
-            }
-            .padding(.bottom, 8)
-            Text(viewModel.user.introduction ?? "")
-                .font(.system(size: 12, weight: .regular))
-                .foregroundColor(.secondary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 20)
-            /// 高さを取りすぎないように4行に制限
-                .lineLimit(4)
-            
-            if let result = viewModel.user.fortuneResult {
-                VStack(spacing: 16) {
-                    Text("今日の都道府県")
-                        .font(.system(size: 32, weight: .semibold))
-                    
-                    HStack {
-                        VStack {
-                            Spacer()
-                            Text(result.prefecture.name)
-                                .font(.system(size: 50, weight: .bold))
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.5)
-                            Text(result.prefecture.capital)
-                                .font(.system(size: 35, weight: .medium))
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.5)
-                            Spacer()
-                        }
-                        if let iconImage = viewModel.logoImage {
-                            Image(uiImage: iconImage)
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 100, height: 100)
-                                .clipShape(Circle())
-                        } else {
-                            Circle()
-                                .fill(.clear)
-                                .frame(width: 100, height: 100)
-                                .overlay {
-                                    ProgressView()
-                                }
-                        }
-                    }
-                    
-                    Text(result.prefecture.brief)
-                        .font(.system(size: 16, weight: .regular))
-                        .foregroundColor(.secondary)
-                    
-                    if let citizenDay = result.prefecture.citizenDay {
-                        HStack {
-                            Text("県民の日")
-                                .font(.system(size: 35, weight: .semibold))
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                            Text(formatMonthDay(citizenDay))
-                                .font(.system(size: 35, weight: .semibold))
-                                .frame(maxWidth: .infinity, alignment: .trailing)
-                        }
-                    }
-                    Text(result.prefecture.hasCoastLine ? "海沿い" : "内陸")
-                        .font(.system(size: 32, weight: .semibold))
-                        .foregroundColor(.secondary)
                 }
-                .padding(.horizontal, 30)
-                .padding(.vertical, 16)
-                .frame(maxWidth: .infinity, alignment: .center)
-                .background(.background)
-                .cornerRadius(20)
-                .padding(20)
-                .shadow(color:.primary.opacity(0.4), radius: 10, x: 0, y: 4)
-            } else {
-                ProgressView()
-                    .padding(30)
+                
+                Text(viewModel.user.name)
+                    .font(.system(size: 32, weight: .semibold))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 20)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.5)
+                
+                HStack {
+                    Spacer()
+                    Text(viewModel.user.bloodType.displayName + "型")
+                        .font(.system(size: 16, weight: .medium))
+                        .lineLimit(1)
+                    /// gift.fillは誕生日のアイコンとする
+                    /// birthdaycakeは複雑すぎて今回のサイズでは視認性が悪いため却下
+                    Image(systemName: "gift.fill")
+                        .scaleEffect(0.8)
+                        .padding(.leading, 20)
+                        .padding(.trailing, -8)
+                    
+                    Text(formatDate(viewModel.user.birthday))
+                        .font(.system(size: 16, weight: .medium))
+                        .padding(.trailing, 20)
+                        .lineLimit(1)
+                }
+                .padding(.bottom, 8)
+                Text(viewModel.user.introduction ?? "")
+                    .font(.system(size: 12, weight: .regular))
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 20)
+                /// 高さを取りすぎないように4行に制限
+                    .lineLimit(4)
+                
+                if let result = viewModel.user.fortuneResult {
+                    VStack(spacing: 16) {
+                        Text("今日の都道府県")
+                            .font(.system(size: 32, weight: .semibold))
+                        
+                        HStack {
+                            VStack {
+                                Spacer()
+                                Text(result.prefecture.name)
+                                    .font(.system(size: 50, weight: .bold))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.5)
+                                Text(result.prefecture.capital)
+                                    .font(.system(size: 35, weight: .medium))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.5)
+                                Spacer()
+                            }
+                            if let iconImage = viewModel.logoImage {
+                                Image(uiImage: iconImage)
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: 100, height: 100)
+                                    .clipShape(Circle())
+                            } else {
+                                Circle()
+                                    .fill(.clear)
+                                    .frame(width: 100, height: 100)
+                                    .overlay {
+                                        ProgressView()
+                                    }
+                            }
+                        }
+                        
+                        Text(result.prefecture.brief)
+                            .font(.system(size: 16, weight: .regular))
+                            .foregroundColor(.secondary)
+                        
+                        if let citizenDay = result.prefecture.citizenDay {
+                            HStack {
+                                Text("県民の日")
+                                    .font(.system(size: 35, weight: .semibold))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                Text(formatMonthDay(citizenDay))
+                                    .font(.system(size: 35, weight: .semibold))
+                                    .frame(maxWidth: .infinity, alignment: .trailing)
+                            }
+                        }
+                        Text(result.prefecture.hasCoastLine ? "海沿い" : "内陸")
+                            .font(.system(size: 32, weight: .semibold))
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.horizontal, 30)
+                    .padding(.vertical, 16)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .background(.background)
+                    .cornerRadius(20)
+                    .padding(20)
+                    .shadow(color:.primary.opacity(0.4), radius: 10, x: 0, y: 4)
+                } else {
+                    ProgressView()
+                        .padding(30)
+                }
             }
+            .ignoresSafeArea(edges: .top)
+            .sheet(isPresented: $isSheetPresented) {
+                FortuneProfileFormView(user: viewModel.user)
+            }
+            
+            Button(action: {
+                dismiss()
+            }) {
+                Image(systemName: "chevron.backward")
+                    .font(.title3.weight(.bold))
+                    .padding()
+                    .background(Color.accentColor)
+                    .foregroundColor(Color(UIColor.systemBackground))
+                    .clipShape(Circle())
+                    .shadow(radius: 2, x: 0, y: 4)
+            }
+            .padding()
+            .padding(.top, 20)
+            .ignoresSafeArea(edges: .top)
+
         }
-        .ignoresSafeArea(edges: .top)
-        .sheet(isPresented: $isSheetPresented) {
-            FortuneProfileFormView(user: viewModel.user)
-        }
+        .navigationBarHidden(true)
     }
     
     func formatDate(_ date: Date) -> String {

--- a/YumemiPrefectureFortune/View/FortuneDetailView.swift
+++ b/YumemiPrefectureFortune/View/FortuneDetailView.swift
@@ -6,11 +6,22 @@ struct FortuneDetailView: View {
     var body: some View {
         // TODO: 背景色はプレースホルダーの段階で見やすくするためだけなので実装時は削除
         ScrollView {
-            Image("")
-                .resizable()
-                .frame(height: 200)
-                .background(.green)
-            
+            if let headerImage = viewModel.headerImage {
+                Image(uiImage: headerImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(height: 180)
+                    .clipped()
+            } else {
+                // 画像読み込み中のプレースホルダー
+                Rectangle()
+                    .fill(Color(UIColor.systemGray4))
+                    .frame(height: 180)
+                    .overlay {
+                        ProgressView()
+                            .padding(.top, 40)
+                    }
+            }
             HStack {
                 if let iconData = viewModel.user.icon, let uiImage = UIImage(data: iconData) {
                     Image(uiImage: uiImage)
@@ -82,54 +93,57 @@ struct FortuneDetailView: View {
             /// 高さを取りすぎないように4行に制限
                 .lineLimit(4)
             
-            
-            VStack {
-                VStack(spacing: 16) {
-                    Text("今日の都道府県")
-                        .font(.system(size: 32, weight: .semibold))
-                    
-                    HStack {
-                        VStack {
-                            Spacer()
-                            Text("XX県")
-                                .font(.system(size: 50, weight: .bold))
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                            Text("xx市")
-                                .font(.system(size: 35, weight: .medium))
-                                .frame(maxWidth: .infinity, alignment: .center)
-                            Spacer()
-                        }
-                        Image("")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 100, height: 100)
-                            .background(.red)
-                            .clipShape(Circle())
+            if let result = viewModel.user.fortuneResult {
+                
+            } else {
+                VStack {
+                    VStack(spacing: 16) {
+                        Text("今日の都道府県")
+                            .font(.system(size: 32, weight: .semibold))
                         
+                        HStack {
+                            VStack {
+                                Spacer()
+                                Text("XX県")
+                                    .font(.system(size: 50, weight: .bold))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                Text("xx市")
+                                    .font(.system(size: 35, weight: .medium))
+                                    .frame(maxWidth: .infinity, alignment: .center)
+                                Spacer()
+                            }
+                            Image("")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: 100, height: 100)
+                                .background(.red)
+                                .clipShape(Circle())
+                            
+                        }
+                        
+                        Text("Wikipediaによる概要")
+                            .font(.system(size: 16, weight: .regular))
+                            .foregroundColor(.secondary)
+                        
+                        HStack {
+                            Text("県民の日")
+                                .font(.system(size: 35, weight: .semibold))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            Text("MM/DD")
+                                .font(.system(size: 35, weight: .semibold))
+                                .frame(maxWidth: .infinity, alignment: .trailing)
+                        }
+                        Text("内陸／海沿い")
+                            .font(.system(size: 32, weight: .semibold))
                     }
-                    
-                    Text("Wikipediaによる概要")
-                        .font(.system(size: 16, weight: .regular))
-                        .foregroundColor(.secondary)
-
-                    HStack {
-                        Text("県民の日")
-                            .font(.system(size: 35, weight: .semibold))
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        Text("MM/DD")
-                            .font(.system(size: 35, weight: .semibold))
-                            .frame(maxWidth: .infinity, alignment: .trailing)
-                    }
-                    Text("内陸／海沿い")
-                        .font(.system(size: 32, weight: .semibold))
+                    .padding(.horizontal, 30)
+                    .padding(.vertical, 16)
                 }
-                .padding(.horizontal, 30)
-                .padding(.vertical, 16)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .background(Color.yellow)
+                .cornerRadius(20)
+                .padding(20)
             }
-            .frame(maxWidth: .infinity, alignment: .center)
-            .background(Color.yellow)
-            .cornerRadius(20)
-            .padding(20)
         }
         .ignoresSafeArea(edges: .top)
     }

--- a/YumemiPrefectureFortune/View/FortuneDetailView.swift
+++ b/YumemiPrefectureFortune/View/FortuneDetailView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct FortuneDetailView: View {
+    var body: some View {
+    }
+}
+
+#Preview("light") {
+    FortuneDetailView()
+            .preferredColorScheme(.light)
+
+    
+}
+
+#Preview("dark") {
+    FortuneDetailView()
+            .preferredColorScheme(.dark)
+
+    
+}

--- a/YumemiPrefectureFortuneUITests/FortuneDetailViewUITests.swift
+++ b/YumemiPrefectureFortuneUITests/FortuneDetailViewUITests.swift
@@ -1,0 +1,88 @@
+import XCTest
+
+final class FortuneDetailViewUITests: XCTestCase {
+    
+    var app: XCUIApplication!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launch()
+    }
+    
+    /// ユーザー情報と占い結果が正常に表示されることをテストする
+    func testDetailView_HappyPath() throws {
+        // --- 準備 ---
+        // リストの最初のセルをタップして詳細画面に遷移
+        let firstCell = app.collectionViews.cells.firstMatch
+        XCTAssertTrue(firstCell.waitForExistence(timeout: 5), "ユーザーリストが表示されません")
+        firstCell.tap()
+        
+        // --- 検証 ---
+        // 1. 主要なボタンが表示されていることを確認
+        let backButton = app.buttons["backButton"]
+        let editButton = app.buttons["editButton"]
+        XCTAssertTrue(backButton.waitForExistence(timeout: 2))
+        XCTAssertTrue(editButton.waitForExistence(timeout: 2))
+        
+        // 2. ローディングインジケーターが消えるまで待つ (API通信が終わるまで)
+        let loadingIndicator = app.otherElements["loadingIndicator"]
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "exists == false"),
+            object: loadingIndicator
+        )
+        wait(for: [expectation], timeout: 15)
+        
+        // 3. 占い結果の主要な要素が表示されるのを待機し、アサートする
+        let userName = app.staticTexts["userNameText"]
+        let prefectureName = app.staticTexts["prefectureNameText"]
+
+        XCTAssertTrue(userName.waitForExistence(timeout: 5), "ユーザー名が表示されません")
+        XCTAssertTrue(prefectureName.waitForExistence(timeout: 5), "都道府県名が表示されません")
+        
+        // 4. 表示されているテキストが空でないことを確認
+        XCTAssertNotEqual(userName.label, "")
+        XCTAssertNotEqual(prefectureName.label, "")
+    }
+    
+    /// 「戻る」ボタンをタップしてリスト画面に戻れることをテストする
+    func testNavigation_BackButton() throws {
+        // --- 準備 ---
+        // リストの最初のセルをタップして詳細画面に遷移
+        let firstCell = app.collectionViews.cells.firstMatch
+        XCTAssertTrue(firstCell.waitForExistence(timeout: 5))
+        firstCell.tap()
+        
+        // --- 操作 ---
+        // 戻るボタンをタップ
+        let backButton = app.buttons["backButton"]
+        XCTAssertTrue(backButton.waitForExistence(timeout: 2))
+        backButton.tap()
+        
+        // --- 検証 ---
+        // リスト画面のタイトルが表示されていることを確認して、画面が戻ったと判断
+        let listTitle = app.navigationBars["ともだちリスト"]
+        XCTAssertTrue(listTitle.waitForExistence(timeout: 2))
+    }
+    
+    /// 「編集」ボタンをタップしてプロフィール編集シートが表示されることをテストする
+    func testNavigation_EditButton() throws {
+        // --- 準備 ---
+        // リストの最初のセルをタップして詳細画面に遷移
+        let firstCell = app.collectionViews.cells.firstMatch
+        XCTAssertTrue(firstCell.waitForExistence(timeout: 5))
+        firstCell.tap()
+        
+        // --- 操作 ---
+        // 編集ボタンをタップ
+        let editButton = app.buttons["editButton"]
+        XCTAssertTrue(editButton.waitForExistence(timeout: 2))
+        editButton.tap()
+        
+        // --- 検証 ---
+        // 編集画面の「保存」ボタンが表示されることで、シートが表示されたと判断
+        let saveButton = app.buttons["save"]
+        XCTAssertTrue(saveButton.waitForExistence(timeout: 2))
+    }
+}


### PR DESCRIPTION
## 概要
占い結果を表示する詳細画面を新規に実装  

## 主な変更点
- 占い詳細画面 (`FortuneDetailView`)
  - APIから取得した占い結果とユーザー情報を動的に表示
  - 標準ナビゲーションバーを隠し、カスタムの「戻る」ボタンとフルスクリーンのスワイプバックジェスチャーを実装
  - スクロールに追従するヘッダー画像エフェクトを追加
  - プロフィール編集画面をシート表示できるように追加

- UIテスト
  - 詳細画面の表示確認と「戻る」「編集」ボタンの動作を検証するUIテスト (`FortuneDetailViewUITests`) を追加