### PR TITLE
feat: ユーザーリストにスワイプ削除機能とUIテストを追加

### DIFF
--- a/YumemiPrefectureFortune.xcodeproj/project.pbxproj
+++ b/YumemiPrefectureFortune.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		701F649D2E6FD48700495698 /* DESIGN.md in Resources */ = {isa = PBXBuildFile; fileRef = 701F649C2E6FD48700495698 /* DESIGN.md */; };
 		701F649F2E6FD49400495698 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 701F649E2E6FD49400495698 /* README.md */; };
 		701F64A12E6FD49A00495698 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 701F64A02E6FD49A00495698 /* Secrets.xcconfig */; };
+		70B210F12E7854C000A4828C /* FortuneUserListViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B210F02E7854C000A4828C /* FortuneUserListViewUITests.swift */; };
 		70B34AA42E755ACA00C58479 /* FortuneProfileFormViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B34AA22E755ACA00C58479 /* FortuneProfileFormViewUITests.swift */; };
 		70E96D242E782215000BB6FF /* FortuneDetailViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E96D232E782215000BB6FF /* FortuneDetailViewUITests.swift */; };
 /* End PBXBuildFile section */
@@ -38,6 +39,7 @@
 		701F649C2E6FD48700495698 /* DESIGN.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = DESIGN.md; sourceTree = "<group>"; };
 		701F649E2E6FD49400495698 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		701F64A02E6FD49A00495698 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
+		70B210F02E7854C000A4828C /* FortuneUserListViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FortuneUserListViewUITests.swift; sourceTree = "<group>"; };
 		70B34AA22E755ACA00C58479 /* FortuneProfileFormViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FortuneProfileFormViewUITests.swift; sourceTree = "<group>"; };
 		70E96D232E782215000BB6FF /* FortuneDetailViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FortuneDetailViewUITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -121,6 +123,7 @@
 			children = (
 				70B34AA22E755ACA00C58479 /* FortuneProfileFormViewUITests.swift */,
 				70E96D232E782215000BB6FF /* FortuneDetailViewUITests.swift */,
+				70B210F02E7854C000A4828C /* FortuneUserListViewUITests.swift */,
 			);
 			path = YumemiPrefectureFortuneUITests;
 			sourceTree = "<group>";
@@ -284,6 +287,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				70B34AA42E755ACA00C58479 /* FortuneProfileFormViewUITests.swift in Sources */,
+				70B210F12E7854C000A4828C /* FortuneUserListViewUITests.swift in Sources */,
 				70E96D242E782215000BB6FF /* FortuneDetailViewUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/YumemiPrefectureFortune/View/FortuneUserListView.swift
+++ b/YumemiPrefectureFortune/View/FortuneUserListView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import SwiftData
 
 struct FortuneUserListView: View {
+    @Environment(\.modelContext) private var modelContext
+    
     @State private var isSheetPresented = false
     
     @Query(sort: [SortDescriptor(\UserProfile.name)]) private var users: [UserProfile]
@@ -10,30 +12,34 @@ struct FortuneUserListView: View {
         NavigationStack {
             ZStack(alignment: .bottomTrailing) {
                 
-                List(users) { user in
-                    NavigationLink(
-                        destination:FortuneDetailView(viewModel: FortuneDetailViewModel(user: user))) {
-                            HStack(spacing: 16) {
-                                if let iconData = user.icon, let uiImage = UIImage(data: iconData) {
-                                    Image(uiImage: uiImage)
-                                        .resizable()
-                                        .aspectRatio(contentMode: .fill)
-                                        .frame(width: 44, height: 44)
-                                        .clipShape(Circle())
-                                } else {
-                                    Image(systemName: "person.circle.fill")
-                                        .resizable()
-                                        .aspectRatio(contentMode: .fit)
-                                        .frame(width: 44, height: 44)
-                                        .foregroundColor(Color(UIColor.placeholderText))
+                List {
+                    ForEach(users) { user in
+                        NavigationLink(
+                            destination: FortuneDetailView(viewModel: FortuneDetailViewModel(user: user))) {
+                                HStack(spacing: 16) {
+                                    if let iconData = user.icon, let uiImage = UIImage(data: iconData) {
+                                        Image(uiImage: uiImage)
+                                            .resizable()
+                                            .aspectRatio(contentMode: .fill)
+                                            .frame(width: 44, height: 44)
+                                            .clipShape(Circle())
+                                    } else {
+                                        Image(systemName: "person.circle.fill")
+                                            .resizable()
+                                            .aspectRatio(contentMode: .fit)
+                                            .frame(width: 44, height: 44)
+                                            .foregroundColor(Color(UIColor.placeholderText))
+                                    }
+                                    Text(user.name)
+                                        .font(.title3)
+                                        .lineLimit(1)
+                                        .truncationMode(.tail)
                                 }
-                                Text(user.name)
-                                    .font(.title3)
-                                    .lineLimit(1)
-                                    .truncationMode(.tail)
+                                .padding(.vertical, 4)
                             }
-                            .padding(.vertical, 4)
-                        }
+                    }
+                    // `.onDelete(perform:)` が IndexSet を自動的に渡してくれる
+                    .onDelete(perform: deleteUsers)
                 }
                 .navigationTitle("ともだちリスト")
                 .sheet(isPresented: $isSheetPresented) {
@@ -53,6 +59,13 @@ struct FortuneUserListView: View {
                 }
                 .padding()
             }
+        }
+    }
+    
+    private func deleteUsers(at offsets: IndexSet) {
+        for index in offsets {
+            let userToDelete = users[index]
+            modelContext.delete(userToDelete)
         }
     }
 }

--- a/YumemiPrefectureFortune/View/FortuneUserListView.swift
+++ b/YumemiPrefectureFortune/View/FortuneUserListView.swift
@@ -34,6 +34,7 @@ struct FortuneUserListView: View {
                                         .font(.title3)
                                         .lineLimit(1)
                                         .truncationMode(.tail)
+                                        .accessibilityIdentifier(user.name)
                                 }
                                 .padding(.vertical, 4)
                             }
@@ -58,6 +59,7 @@ struct FortuneUserListView: View {
                         .shadow(radius: 2, x: 0, y: 4)
                 }
                 .padding()
+                .accessibilityIdentifier("addUserButton")
             }
         }
     }

--- a/YumemiPrefectureFortune/YumemiPrefectureFortuneApp.swift
+++ b/YumemiPrefectureFortune/YumemiPrefectureFortuneApp.swift
@@ -5,6 +5,12 @@ import SwiftData
 @main
 struct YumemiPrefectureFortuneApp: App {
     var sharedModelContainer: ModelContainer = {
+        // UIテスト実行中は、サンプルデータを含むインメモリコンテナを返す
+        if ProcessInfo.processInfo.arguments.contains("-UITesting") {
+            return SampleUserData.previewContainer
+        }
+        
+        // 通常起動時は、永続化コンテナを返す
         let schema = Schema([
             UserProfile.self,
         ])

--- a/YumemiPrefectureFortuneUITests/FortuneDetailViewUITests.swift
+++ b/YumemiPrefectureFortuneUITests/FortuneDetailViewUITests.swift
@@ -8,6 +8,7 @@ final class FortuneDetailViewUITests: XCTestCase {
         try super.setUpWithError()
         continueAfterFailure = false
         app = XCUIApplication()
+        app.launchArguments += ["-UITesting"]
         app.launch()
     }
     

--- a/YumemiPrefectureFortuneUITests/FortuneProfileFormViewUITests.swift
+++ b/YumemiPrefectureFortuneUITests/FortuneProfileFormViewUITests.swift
@@ -10,6 +10,7 @@ final class FortuneProfileFormViewUITests: XCTestCase {
         app = XCUIApplication()
         // テストのたびにデータをリセットしたい場合は、起動引数を設定することが多いです
         // app.launchArguments += ["-UITesting"]
+        app.launchArguments += ["-UITesting"]
         app.launch()
     }
     

--- a/YumemiPrefectureFortuneUITests/FortuneProfileFormViewUITests.swift
+++ b/YumemiPrefectureFortuneUITests/FortuneProfileFormViewUITests.swift
@@ -27,6 +27,7 @@ final class FortuneProfileFormViewUITests: XCTestCase {
         XCTAssertTrue(nameTextField.waitForExistence(timeout: 1))
         nameTextField.tap()
         nameTextField.typeText("テストユーザー")
+        app.keyboards.buttons["Return"].tap() // キーボードを閉じる
         
         // 2. 生年月日の選択
         let birthdayButton = app.buttons["birthdaySelectionButton"]
@@ -99,6 +100,7 @@ final class FortuneProfileFormViewUITests: XCTestCase {
         XCTAssertTrue(nameTextField.waitForExistence(timeout: 1))
         nameTextField.tap()
         nameTextField.typeText("テストユーザー")
+        app.keyboards.buttons["Return"].tap() // キーボードを閉じる
         
         let bloodTypePicker = app.buttons["bloodTypePicker"]
         bloodTypePicker.tap()
@@ -136,6 +138,7 @@ final class FortuneProfileFormViewUITests: XCTestCase {
         XCTAssertTrue(nameTextField.waitForExistence(timeout: 1))
         nameTextField.tap()
         nameTextField.typeText("テストユーザー")
+        app.keyboards.buttons["Return"].tap() // キーボードを閉じる
         
         let birthdayButton = app.buttons["birthdaySelectionButton"]
         birthdayButton.tap()

--- a/YumemiPrefectureFortuneUITests/FortuneUserListViewUITests.swift
+++ b/YumemiPrefectureFortuneUITests/FortuneUserListViewUITests.swift
@@ -1,0 +1,77 @@
+import XCTest
+
+final class FortuneUserListViewUITests: XCTestCase {
+
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments += ["-UITesting"]
+        app.launch()
+    }
+
+    /// リストのセルをタップして詳細画面に正しく遷移するかをテストする
+    func testNavigationToDetailView() throws {
+        // --- 準備 ---
+        // サンプルユーザーがリストに表示されるのを待つ
+        let firstCell = app.collectionViews.cells.firstMatch
+        XCTAssertTrue(firstCell.waitForExistence(timeout: 5), "リストにユーザーが表示されません")
+
+        // --- 操作 ---
+        firstCell.tap()
+
+        // --- 検証 ---
+        // 詳細画面の「戻る」ボタンが表示されることで、画面遷移を検証する
+        let backButtonOnDetail = app.buttons["backButton"]
+        XCTAssertTrue(backButtonOnDetail.waitForExistence(timeout: 2), "詳細画面への遷移に失敗しました")
+    }
+
+    /// ユーザーをスワイプして削除する機能をテストする
+    func testDeleteUser_byIdentifier() throws {
+        // --- 準備 ---
+        // サンプルユーザー「山田 太郎」を削除対象とする
+        let userCell = app.staticTexts["山田 太郎"]
+        XCTAssertTrue(userCell.waitForExistence(timeout: 5), "サンプルユーザー「山田 太郎」がリストに表示されません")
+
+        // --- 操作 ---
+        userCell.swipeLeft()
+        let deleteButton = app.buttons["Delete"]
+        XCTAssertTrue(deleteButton.waitForExistence(timeout: 1), "スワイプ後に削除ボタンが表示されません")
+        deleteButton.tap()
+
+        // --- 検証 ---
+        // ユーザーがリストから消えるのを待つ
+        let predicate = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: userCell)
+        wait(for: [expectation], timeout: 5)
+
+        XCTAssertFalse(userCell.exists, "ユーザーがリストから削除されていません")
+    }
+    
+    /// ユーザー削除後にリストの総数が減ることをテストする
+    func testDeleteUser_ReducesCellCount() throws {
+        // --- 準備 ---
+        // サンプルユーザーが表示されるのを待つ
+        let cells = app.collectionViews.cells
+        XCTAssertTrue(cells.firstMatch.waitForExistence(timeout: 5), "リストにセルが表示されません")
+        let initialCellCount = cells.count
+        
+        // --- 操作 ---
+        // 最初のセルをスワイプして削除
+        let firstCell = cells.firstMatch
+        firstCell.swipeLeft()
+        let deleteButton = app.buttons["Delete"]
+        XCTAssertTrue(deleteButton.waitForExistence(timeout: 1))
+        deleteButton.tap()
+        
+        // --- 検証 ---
+        // セルの総数が1つ減るのを待つ
+        let predicate = NSPredicate(format: "count == %d", initialCellCount - 1)
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: cells)
+        wait(for: [expectation], timeout: 5)
+        
+        XCTAssertEqual(cells.count, initialCellCount - 1, "セルの数が期待通りに減りませんでした")
+    }
+}


### PR DESCRIPTION
## 概要

ユーザーリスト画面 (`FortuneUserListView`) にスワイプによるユーザー削除機能を追加し、その動作を検証するUIテストを実装
既存のUIテストの安定性向上と、UIテスト実行時のデータ管理を改善

## 変更点

### 機能追加・改善
- **ユーザーリストのスワイプ削除機能**
    - `FortuneUserListView` に `.onDelete` モディファイアを追加し、リストの行を左にスワイプすることでユーザーを削除可能にした
    - `ModelContext` を使用してSwiftDataからユーザーデータを永続的に削除

- **UIテスト時のデータコンテナ切り替え**
    - アプリ起動時に `-UITesting` 引数が渡された場合、`SampleUserData.previewContainer`（インメモリのサンプルデータ）を使用するように `YumemiPrefectureFortuneApp` を変更
    - UIテストの実行環境を常にクリーンで予測可能にした

### UIテスト
- **`FortuneUserListViewUITests` の追加**
    - ユーザーリスト画面の主要な動作を検証するUIテストを追加
        - リストのセルをタップして詳細画面に正しく遷移することを確認
        - ユーザーをスワイプして削除できること、および削除後にリストからユーザーが消えることを確認
        - ユーザー削除後にリストの総数が正しく減少することを確認

- **既存UIテストの安定性向上**
    - `FortuneDetailViewUITests` および `FortuneProfileFormViewUITests` に `-UITesting` 起動引数を追加
    - `FortuneProfileFormViewUITests` において、テキスト入力後にキーボードを閉じる処理（`app.keyboards.buttons["Return"].tap()`）を追加し、後続のUI要素が隠れることによるテスト失敗を防ぎ安定性を向上
