### PR TITLE
feat: 新規ユーザー向けガイド機能の追加

### DIFF
--- a/YumemiPrefectureFortune/View/EmptyListView.swift
+++ b/YumemiPrefectureFortune/View/EmptyListView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+struct EmptyListView: View {
+    @State private var stars: [Star] = []
+    let starCount = 10
+    let margin: CGFloat = 20
+
+    var body: some View {
+        ZStack {
+            Color(UIColor.systemBackground)
+                .ignoresSafeArea()
+            
+            ForEach(stars) { star in
+                Image(systemName: "star.fill")
+                    .foregroundColor(.accent)
+                    .frame(width: star.size, height: star.size)
+                    .position(x: star.x, y: star.y)
+                    .opacity(star.opacity)
+                    .animation(.easeInOut(duration: 0.5), value: star.opacity)
+            }
+
+            VStack(spacing: 16) {
+                Image(systemName: "moon.stars.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 80, height: 80)
+                    .foregroundStyle(.accent)
+                
+                Text("プロフィールを入力して\nぴったりの都道府県を占おう")
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.5)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear {
+            let screenWidth = UIScreen.main.bounds.width
+            let screenHeight = UIScreen.main.bounds.height
+
+            // 星の初期生成
+            for _ in 0..<starCount {
+                let star = Star(
+                    x: CGFloat.random(in: margin...(screenWidth - margin)),
+                    y: CGFloat.random(in: margin...(screenHeight - margin)),
+                    size: CGFloat.random(in: 4...10),
+                    opacity: 0.0
+                )
+                stars.append(star)
+                scheduleStarToggle(for: star.id, screenWidth: screenWidth, screenHeight: screenHeight)
+            }
+        }
+    }
+    
+    func scheduleStarToggle(for id: UUID, screenWidth: CGFloat, screenHeight: CGFloat) {
+        let duration = Double.random(in: 1.0...3.0)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+            if let index = stars.firstIndex(where: { $0.id == id }) {
+                if stars[index].opacity > 0 {
+                    withAnimation(.easeOut(duration: 0.5)) {
+                        stars[index].opacity = 0.0
+                    }
+                } else {
+                    stars[index].x = CGFloat.random(in: margin...(screenWidth - margin))
+                    stars[index].y = CGFloat.random(in: margin...(screenHeight - margin))
+                    withAnimation(.easeIn(duration: 0.5)) {
+                        stars[index].opacity = 1.0
+
+                    }
+                }
+
+                scheduleStarToggle(for: id, screenWidth: screenWidth, screenHeight: screenHeight)
+            }
+        }
+    }
+}
+
+struct Star: Identifiable {
+    let id = UUID()
+    var x: CGFloat
+    var y: CGFloat
+    var size: CGFloat
+    var opacity: Double
+}
+
+#Preview {
+    EmptyListView()
+}

--- a/YumemiPrefectureFortune/View/EmptyListView.swift
+++ b/YumemiPrefectureFortune/View/EmptyListView.swift
@@ -26,7 +26,7 @@ struct EmptyListView: View {
                     .frame(width: 80, height: 80)
                     .foregroundStyle(.accent)
                 
-                Text("プロフィールを入力して\nぴったりの都道府県を占おう")
+                Text("プロフィールを入力して\nぴったりの都道府県を占おう！")
                     .font(.system(size: 24, weight: .semibold))
                     .foregroundColor(.secondary)
                     .lineLimit(2)

--- a/YumemiPrefectureFortune/View/FortuneDetailView.swift
+++ b/YumemiPrefectureFortune/View/FortuneDetailView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct FortuneDetailView: View {
     @Environment(\.dismiss) private var dismiss
     
+    @AppStorage("hasSeenTutorial") var hasSeenTutorial: Bool = false
+
     @StateObject var viewModel: FortuneDetailViewModel
     @State var isSheetPresented = false
     
@@ -190,6 +192,11 @@ struct FortuneDetailView: View {
 
         }
         .navigationBarHidden(true)
+        .overlay {
+            if !hasSeenTutorial {
+                TutorialView()
+            }
+        }
     }
     
     func formatDate(_ date: Date) -> String {

--- a/YumemiPrefectureFortune/View/FortuneUserListView.swift
+++ b/YumemiPrefectureFortune/View/FortuneUserListView.swift
@@ -47,6 +47,13 @@ struct FortuneUserListView: View {
                     FortuneProfileFormView(user: nil)
                 }
                 
+                if users.isEmpty {
+                    EmptyListView()
+                        .onTapGesture {
+                            isSheetPresented = true
+                        }
+                }
+                
                 Button(action: {
                     isSheetPresented = true
                 }) {
@@ -80,9 +87,23 @@ struct FortuneUserListView: View {
     
 }
 
+#Preview("no data(light)") {
+    FortuneUserListView()
+            .preferredColorScheme(.light)
+
+    
+}
+
 #Preview("dark") {
     FortuneUserListView()
             .modelContainer(SampleUserData.previewContainer)
+            .preferredColorScheme(.dark)
+
+    
+}
+
+#Preview("no data(dark)") {
+    FortuneUserListView()
             .preferredColorScheme(.dark)
 
     

--- a/YumemiPrefectureFortune/View/FortuneUserListView.swift
+++ b/YumemiPrefectureFortune/View/FortuneUserListView.swift
@@ -52,6 +52,12 @@ struct FortuneUserListView: View {
                         .onTapGesture {
                             isSheetPresented = true
                         }
+                    
+                    
+                    JumpingArrowView()
+                    /// plusボタンはImage (28pt) + padding 16pt × 2 = 28 + 32 ≈ 60pt
+                    /// よってpaddingを70程度にすることでplusボタンの左上に
+                        .padding(70)
                 }
                 
                 Button(action: {

--- a/YumemiPrefectureFortune/View/JumpingArrowView.swift
+++ b/YumemiPrefectureFortune/View/JumpingArrowView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct JumpingArrowView: View {
+    @State private var offset: CGSize = .zero
+    @State private var jump: Bool = false
+
+    var body: some View {
+        Image(systemName: "arrow.down.right")
+            .font(.system(size: 40, weight: .black))
+            .foregroundColor(.secondary)
+            .offset(offset)
+            .onAppear {
+                let jumpAmount: CGFloat = -10
+                let duration = 0.9
+
+                Timer.scheduledTimer(withTimeInterval: duration, repeats: true) { _ in
+                    withAnimation(.easeInOut(duration: duration)) {
+                        
+                        offset = jump ? .zero : CGSize(width: jumpAmount, height: jumpAmount)
+                        jump.toggle()
+                    }
+                }
+            }
+    }
+}
+
+#Preview("light") {
+    JumpingArrowView()
+        .preferredColorScheme(.light)
+}
+
+#Preview("dark") {
+    JumpingArrowView()
+            .preferredColorScheme(.dark)
+}

--- a/YumemiPrefectureFortune/View/TutorialView.swift
+++ b/YumemiPrefectureFortune/View/TutorialView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+struct TutorialView: View {
+    @AppStorage("hasSeenTutorial") var hasSeenTutorial: Bool = false
+
+    @State private var isVisible = true
+    @State private var isDismissEnabled = false
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.8)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    if isDismissEnabled {
+                        hasSeenTutorial = true
+                    }
+                }
+
+            VStack(spacing: 20) {
+                Text("できること")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .foregroundColor(.white)
+                    .padding(.bottom, 40)
+
+                VStack(alignment: .leading, spacing: 30) {
+                    HStack {
+                        Image(systemName: "pencil.circle.fill")
+                            .font(.largeTitle)
+                            .foregroundColor(.accentColor)
+                        Text("プロフィールを編集できます")
+                            .font(.title2)
+                            .foregroundColor(.white)
+                    }
+                    .padding(.horizontal, 30)
+
+                    HStack {
+                        Image(systemName: "chevron.backward.circle.fill")
+                            .font(.largeTitle)
+                            .foregroundColor(.accentColor)
+                        Text("ユーザーリストに戻ります")
+                            .font(.title2)
+                            .foregroundColor(.white)
+                    }
+                    .padding(.horizontal, 30)
+                    
+                    HStack {
+                        Image(systemName: "moon.stars.circle.fill")
+                            .font(.largeTitle)
+                            .foregroundColor(.accentColor)
+                        Text("今日の占いを表示します")
+                            .font(.title2)
+                            .foregroundColor(.white)
+                    }
+                    .padding(.horizontal, 30)
+
+                }
+
+                Spacer()
+
+                Text("画面のどこかをタップして閉じる")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .padding(.bottom, 50)
+                    .opacity(isVisible ? 0.8 : 0.3)
+                    .onAppear {
+                        withAnimation(Animation.easeInOut(duration: 1).repeatForever(autoreverses: true)) {
+                            isVisible.toggle()
+                        }
+                    }
+            }
+            .padding(.top, 100)
+            .onAppear {
+                /// 1秒後にボタンを有効化
+                /// 画面遷移直後の誤タップを防ぐため
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                    isDismissEnabled = true
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    TutorialView()
+}


### PR DESCRIPTION
## 概要

アプリを初めて利用するユーザーが操作に迷わないよう、新規ユーザー向けのガイド機能を追加しました。

## 変更点

1. 空のユーザーリスト画面の改善
   - ユーザーが一人も登録されていない場合に、プロフィール作成を促すメッセージとアニメーションを表示
   - 画面タップでプロフィール作成画面に遷移
   - ユーザー追加ボタンを指し示す跳ねる矢印アニメーションを追加し、次のアクションを分かりやすく表示

2. 占い詳細画面のチュートリアル
   - 初めて占い詳細画面を開いた際に、主要機能（プロフィール編集、リストへの復帰など）を説明するチュートリアルを表示
   - チュートリアルは初回のみ表示され、画面の任意の場所をタップすると閉じることが可能