### PR TITLE
feat: 新規ユーザー作成後に詳細画面へ自動遷移

### DIFF
--- a/YumemiPrefectureFortune/View/FortuneProfileFormView.swift
+++ b/YumemiPrefectureFortune/View/FortuneProfileFormView.swift
@@ -15,11 +15,14 @@ struct FortuneProfileFormView: View {
     @State private var validationError: Error?
     @State private var showValidationErrorAlert: Bool = false
     
+    var onSave: ((UserProfile) -> Void)?
+    
     private let labelWidth: CGFloat = 80
     private let componentHeight: CGFloat = 24
     
-    init(user: UserProfile?) {
+    init(user: UserProfile?, onSave: ((UserProfile) -> Void)? = nil) {
         _viewModel = StateObject(wrappedValue: FortuneProfileFormViewModel(user: user))
+        self.onSave = onSave
     }
     
     var body: some View {
@@ -197,6 +200,7 @@ struct FortuneProfileFormView: View {
                                 modelContext.insert(savedProfile)
                             }
                             
+                            onSave?(savedProfile)
                             dismiss()
                         } catch {
                             self.validationError = error

--- a/YumemiPrefectureFortune/View/FortuneUserListView.swift
+++ b/YumemiPrefectureFortune/View/FortuneUserListView.swift
@@ -5,11 +5,12 @@ struct FortuneUserListView: View {
     @Environment(\.modelContext) private var modelContext
     
     @State private var isSheetPresented = false
+    @State private var path = NavigationPath()
     
     @Query(sort: [SortDescriptor(\UserProfile.name)]) private var users: [UserProfile]
     
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $path) {
             ZStack(alignment: .bottomTrailing) {
                 
                 List {
@@ -43,8 +44,13 @@ struct FortuneUserListView: View {
                     .onDelete(perform: deleteUsers)
                 }
                 .navigationTitle("ともだちリスト")
+                .navigationDestination(for: UserProfile.self) { user in
+                    FortuneDetailView(viewModel: FortuneDetailViewModel(user: user))
+                }
                 .sheet(isPresented: $isSheetPresented) {
-                    FortuneProfileFormView(user: nil)
+                    FortuneProfileFormView(user: nil) { savedUser in
+                        path.append(savedUser)
+                    }
                 }
                 
                 if users.isEmpty {


### PR DESCRIPTION
## 概要

ユーザー体験向上のため、プロフィールを新規作成した直後に、そのユーザーの占い詳細画面へ自動的に遷移する機能を追加しました。

### 変更点

1. **プロフィール作成画面の改修 (`FortuneProfileFormView`)**
   - 保存成功時に、作成されたユーザー情報を親Viewに通知するためのコールバック（`onSave`）を追加。

2. **ユーザーリスト画面の改修 (`FortuneUserListView`)**
   - `NavigationStack` と `NavigationPath` を利用し、プログラムによる画面遷移を実装。
   - プロフィール作成画面からのコールバックを受け取ると、新しく作成されたユーザーのIDを `NavigationPath` に追加し、詳細画面への遷移をトリガー。