### PR TITLE
fix: プロフィール編集後に占いを自動で再実行する機能を追加

### DIFF
--- a/YumemiPrefectureFortune/View/FortuneDetailView.swift
+++ b/YumemiPrefectureFortune/View/FortuneDetailView.swift
@@ -171,7 +171,9 @@ struct FortuneDetailView: View {
             }
             .ignoresSafeArea(edges: .top)
             .sheet(isPresented: $isSheetPresented) {
-                FortuneProfileFormView(user: viewModel.user)
+                FortuneProfileFormView(user: viewModel.user) { savedUser in
+                    viewModel.fetchFortuneFromAPI(for: savedUser)
+                }
             }
             
             Button(action: {


### PR DESCRIPTION
占い詳細画面でプロフィールを編集・保存した後自動的に占いを再実行して表示を更新するように

- `FortuneDetailView` からプロフィール編集画面を呼び出す際に保存完了後のコールバックを渡すように変更
- コールバック内で `viewModel.fetchFortuneFromAPI` を呼び出し更新されたプロフィール情報で占いを再実行