### PR TITLE
fix: 細かいレイアウトとコードの修正

### DIFF
--- a/YumemiPrefectureFortune/View/FortuneProfileFormView.swift
+++ b/YumemiPrefectureFortune/View/FortuneProfileFormView.swift
@@ -158,8 +158,7 @@ struct FortuneProfileFormView: View {
                             VStack {
                                 if viewModel.introduction?.isEmpty ?? true {
                                     Text("任意")
-                                        .frame(width: .infinity,
-                                               height: componentHeight,
+                                        .frame(height: componentHeight,
                                                alignment: .leading)
                                         .foregroundColor(Color(UIColor.placeholderText))
                                     Spacer()

--- a/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
+++ b/YumemiPrefectureFortune/ViewModel/FortuneDetailViewModel.swift
@@ -46,13 +46,13 @@ final class FortuneDetailViewModel: ObservableObject {
                 // APIエラーをハンドリング
                 await MainActor.run {
                     // TODO: エラー内容をアラートで表示するなどの処理
-                    print("APIエラー: \\(apiError)")
+                    print("APIエラー: \(apiError)")
                     self.isLoading = false
                 }
             } catch {
                 // その他の予期せぬエラー
                 await MainActor.run {
-                    print("不明なエラー: \\(error)")
+                    print("不明なエラー: \(error)")
                     self.isLoading = false
                 }
             }


### PR DESCRIPTION
## 概要
開発中に見つかった軽微なレイアウトの問題と、コード品質に関する細かい点を修正しました。
軽微な修正でアプリ動作への影響はありません。
## 変更点
- プロフィールフォームのレイアウト修正 (`FortuneProfileFormView`)
  - 自己紹介欄のプレースホルダーテキストに設定されていた不要な `frame(width: .infinity)` 修飾子を削除し、レイアウトの整合性を改善。

- ViewModelのコードクリーンアップ (`FortuneDetailViewModel`)
  - エラー出力の `print` 文に含まれていた不要なエスケープ文字（バックスラッシュ）を削除。