### PR TITLE
  feat: ユーザーリストを最終アクセス順にソート

### DIFF
--- a/YumemiPrefectureFortune/Model/UserProfile.swift
+++ b/YumemiPrefectureFortune/Model/UserProfile.swift
@@ -17,7 +17,9 @@ final class UserProfile {
     private(set) var bloodType: BloodType
     private(set) var introduction: String?
     private(set) var icon: Data?
-        
+    
+    private(set) var lastAccessedAt: Date?
+    
     @Transient var fortuneResult: FortuneResult?
     
     // MARK: - Initializer
@@ -35,6 +37,8 @@ final class UserProfile {
         self.bloodType = bloodType
         self.introduction = introduction
         self.icon = icon
+        
+        self.lastAccessedAt = Date()
     }
     
     // MARK: - Mutating Methods
@@ -54,5 +58,6 @@ final class UserProfile {
     
     public func updateFortune(with result: FortuneResult?) {
         self.fortuneResult = result
+        self.lastAccessedAt = Date()
     }
 }

--- a/YumemiPrefectureFortune/View/FortuneUserListView.swift
+++ b/YumemiPrefectureFortune/View/FortuneUserListView.swift
@@ -7,7 +7,7 @@ struct FortuneUserListView: View {
     @State private var isSheetPresented = false
     @State private var path = NavigationPath()
     
-    @Query(sort: [SortDescriptor(\UserProfile.name)]) private var users: [UserProfile]
+    @Query(sort: [SortDescriptor(\UserProfile.lastAccessedAt)]) private var users: [UserProfile]
     
     var body: some View {
         NavigationStack(path: $path) {

--- a/YumemiPrefectureFortune/View/FortuneUserListView.swift
+++ b/YumemiPrefectureFortune/View/FortuneUserListView.swift
@@ -7,7 +7,7 @@ struct FortuneUserListView: View {
     @State private var isSheetPresented = false
     @State private var path = NavigationPath()
     
-    @Query(sort: [SortDescriptor(\UserProfile.lastAccessedAt)]) private var users: [UserProfile]
+    @Query(sort: [SortDescriptor(\UserProfile.lastAccessedAt, order: .reverse)]) private var users: [UserProfile]
     
     var body: some View {
         NavigationStack(path: $path) {


### PR DESCRIPTION
## 概要
ユーザーの利便性向上のため、友だちリストの表示順を従来の「名前順」から「最終アクセス日時順（降順）」に変更しました。

## 変更点

1. **`UserProfile` モデルの拡張**
   - プロフィールの最終利用日時を記録するための `lastAccessedAt` プロパティをモデルに追加。
   - この日時は、プロフィールの新規作成時や占い実行時に更新されます。

2. **リストのソート順変更 (`FortuneUserListView`)**
   - `@Query` の `sort` ディスクリプタを `lastAccessedAt` に変更。
   - 降順（最新アクセス順）でデータを取得するように設定。